### PR TITLE
Adjust example of streamFilterAcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ streamFilterAcc:: (beta -> alpha -> beta) ->  -- the accumulator fn:
                                               --- and computes
                                               --- the new accumulator
                   beta ->                     -- initial accumulator value
-                  (alpha -> beta -> Bool) ->  -- the filter fn: takes head                                                      
+                  (alpha -> beta -> Bool) ->  -- the filter fn: takes head
                                               --- of stream & accumulator
                   Stream alpha ->             -- input stream
                   Stream alpha                -- output stream
@@ -105,9 +105,9 @@ An example of its use is where we only want to propagate an event if its value i
 
 ```haskell
 changes:: Eq alpha=> Stream alpha -> Stream alpha
-changes s = streamFilterAcc (\acc h -> if (h==acc) then acc else h) 
-                            (value $ head s) 
-                            (\h acc->(h/=acc))
+changes s = streamFilterAcc (\_ h -> h)
+                            (value $ head s)
+                            (/=)
                             (tail s)
 ```
 


### PR DESCRIPTION
I found the given accumulator function confusing:

    \acc h -> if (h==acc) then acc else h

Since this equates to

    \_ h -> h

I thought there must be a mistake somewhere. There isn't it's correct,
but since it jumped out at me I thought best to rewrite it. Similarly
rewrite the test parameter.