### PR TITLE
pipeline example: Remove TTY from link node

### DIFF
--- a/examples/pipeline/docker-compose.yml
+++ b/examples/pipeline/docker-compose.yml
@@ -1,21 +1,17 @@
 haskellserver:
   build: server
-  # image: sjwoodman/haskell-server
   ports:
     - "9001:9001"
   stdin_open: true
   tty: true
 haskellclient2:
   build: client2
-  # image: sjwoodman/haskell-client2
   links:
     - haskellserver
   ports:
     - "9002:9002"
   stdin_open: true
-  tty: true
 haskellclient:
   build: client
-  # image: sjwoodman/haskell-client
   links:
     - haskellclient2

--- a/examples/pipeline/docker-compose.yml
+++ b/examples/pipeline/docker-compose.yml
@@ -2,7 +2,6 @@ haskellserver:
   build: server
   ports:
     - "9001:9001"
-  stdin_open: true
   tty: true
 haskellclient2:
   build: client2
@@ -10,7 +9,6 @@ haskellclient2:
     - haskellserver
   ports:
     - "9002:9002"
-  stdin_open: true
 haskellclient:
   build: client
   links:


### PR DESCRIPTION
Since the link node does not print anything to its stdout, docker
compose (expecting log output) thinks there is a fault and kills
all the nodes after COMPOSE_HTTP_TIMEOUT (default 60) seconds elapse.

Fixes #13.