### PR TITLE
test suite improvements

### DIFF
--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -310,17 +310,6 @@ test_partition_s0 = assertEqual (createPartitions s0 [(1,[1]),(2,[2])])
                                                                        , parameters = ["print"]
                                                                        , outputType = ""
                                                                        , imports = [] }]})]
--- Test certain inputs generate a failure.
--- Expect an exception to be thrown (not yet implemented, so these tests fail)
-
-test_empty_partitionmap = assertThrowsSome $ createPartitions s0 []
-
--- partition map refers to non-existent graph nodes
-test_too_many_partitions = assertThrowsSome $ createPartitions s0 [(1,[1]),(2,[2]),(3,[3])]
-
--- partition map has multiple references to graph nodes
-test_repeating_nodes = assertThrowsSome $ createPartitions s0 [(1,[1]),(2,[1])]
-
 
 ex21 = createPartitions s1 [(1,[1,2]),(2,[3,4,5,6,7])]
 

--- a/src/TestMain.hs
+++ b/src/TestMain.hs
@@ -4,5 +4,10 @@ module Main where
 
 import Test.Framework
 import {-@ HTF_TESTS @-} Striot.CompileIoT
+import {-@ HTF_TESTS @-} VizGraph
+
+import Striot.FunctionalIoTtypes
+import Striot.FunctionalProcessing
+import Striot.Nodes
 
 main = htfMain htf_importedTests

--- a/src/VizGraph.hs
+++ b/src/VizGraph.hs
@@ -1,4 +1,6 @@
-module VizGraph(drawPartitionedStreamGraph,drawStreamGraph) where
+{-# OPTIONS_GHC -F -pgmF htfpp #-}
+
+module VizGraph(drawPartitionedStreamGraph,drawStreamGraph,htf_thisModulesTests) where
 import Data.List
 import Striot.CompileIoT (printParams, graphEdgesWithTypes, Id, Partition, StreamGraph, opid, operations, parameters, operator)
 import Data.GraphViz
@@ -6,6 +8,7 @@ import Data.Text.Lazy (Text, pack, unpack)
 import qualified Data.Map as Map
 import Data.GraphViz.Printing (toDot, renderDot)
 import Data.GraphViz.Attributes.Complete
+import Test.Framework
 
 
 

--- a/striot.cabal
+++ b/striot.cabal
@@ -25,6 +25,6 @@ library
 
 Executable Test
   hs-source-dirs:      src
-  Main-is:             Striot/TestMain.hs
-  build-depends:       base >= 4.9 && < 4.10, HTF, time >=1.6 && < 1.7, containers >=0.5 && < 0.6
+  Main-is:             TestMain.hs
+  build-depends:       base >=4.9 && <4.10, containers >=0.5 && <0.6, split >=0.2 && <0.3, time >=1.6 && <1.7, network >=2.6 && <2.7, stm >=2.4 && <2.5, HTF, graphviz, text >= 1.2
   Default-language:    Haskell98

--- a/striot.cabal
+++ b/striot.cabal
@@ -23,8 +23,9 @@ library
   hs-source-dirs:      src
   default-language:    Haskell98
 
-Executable Test
+test-suite test-striot
   hs-source-dirs:      src
+  type:                exitcode-stdio-1.0
   Main-is:             TestMain.hs
   build-depends:       base >=4.9 && <4.10, containers >=0.5 && <0.6, split >=0.2 && <0.3, time >=1.6 && <1.7, network >=2.6 && <2.7, stm >=2.4 && <2.5, HTF, graphviz, text >= 1.2
   Default-language:    Haskell98


### PR DESCRIPTION
Convert the Test binary into a Cabal test-suite and import all the Striot modules into it, so that if any of them stop compiling, the test suite will fail (even though they do not yet define any tests!)