### PR TITLE
Fixes to the examples

### DIFF
--- a/examples/expand/Makefile
+++ b/examples/expand/Makefile
@@ -1,15 +1,13 @@
-run: nodes
+run: node1/node1.hs node2/node2.hs
 	docker-compose up --build
-
-nodes: node1/node1.hs node2/node2.hs
 
 node1/node1.hs node2/node2.hs: generate
 	./generate
 
 generate: generate.hs
-	ghc generate -i../../../src
+	ghc generate -i../../src
 
 clean:
 	rm -f generate generate.hi generate.o node1/node1.hs node2/node2.hs
 
-.PHONY: clean nodes
+.PHONY: clean

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -164,7 +164,8 @@ generateSinkFn:: StreamGraph -> String
 generateSinkFn sg = "sink1 :: Show a => Stream a -> IO ()\nsink1 = " ++
     (intercalate "\n" $ parameters $ head $ reverse $ vertexList sg) ++ "\n"
 
-generateNodeLink n = "main = nodeLink streamGraphFn 9001 \"node"++(show n)++"\" 9001"
+generateNodeLink :: Integer -> String
+generateNodeLink n = "main = nodeLink streamGraphFn \"9001\" \"node"++(show n)++"\" \"9001\""
 
 -- warts:
 --  we accept a list of onward nodes but nodeSource only accepts one anyway
@@ -175,6 +176,7 @@ generateNodeSrc partId nodes = let
     port = 9001 + partId -1 -- XXX Unlikely to always be correct
     in "main = nodeSource src1 streamGraphFn \""++host++"\" \""++(show port)++"\""
 
+generateNodeSink :: Int -> String
 generateNodeSink v = case v of
     1 -> "main = nodeSink streamGraphFn sink1 \"9001\""
     2 -> "main = nodeSink2 streamGraphFn sink1 \"9001\" \"9002\""
@@ -184,10 +186,11 @@ generateCodeFromVertex :: (Int, StreamVertex) -> String
 generateCodeFromVertex (opid, v)  = let
     op = operator v
     params = case op of
-        Join   -> []
-        Expand -> []
-        Scan   -> [" ", intercalate " " (parameters v)]
-        _      -> [" (" , intercalate "\n" (parameters v) , ")"]
+        Join      -> []
+        Expand    -> []
+        Scan      -> [" ", intercalate " " (parameters v)]
+        FilterAcc -> [" ", intercalate " " (parameters v)]
+        _         -> [" (" , intercalate "\n" (parameters v) , ")"]
     args = case op of
         Merge -> []
         Join  -> [" n", show (opid-2), " n", show (opid-1)]

--- a/striot.cabal
+++ b/striot.cabal
@@ -27,5 +27,5 @@ test-suite test-striot
   hs-source-dirs:      src
   type:                exitcode-stdio-1.0
   Main-is:             TestMain.hs
-  build-depends:       base >=4.9 && <4.10, containers >=0.5 && <0.6, split >=0.2 && <0.3, time >=1.6 && <1.7, network >=2.6 && <2.7, stm >=2.4 && <2.5, HTF, graphviz, text >= 1.2, aeson, algebraic-graphs >= 0.1
+  build-depends:       base >=4.9 && <4.10, containers >=0.5 && <0.6, split >=0.2 && <0.3, time >=1.6 && <1.7, network >=2.6 && <2.7, stm >=2.4 && <2.5, HTF, aeson, bytestring, unagi-chan, algebraic-graphs >= 0.1
   Default-language:    Haskell98


### PR DESCRIPTION
There were a few bugs that I didn't spot in PR #18 - however I wanted to run this past you @jmtd.

- I have changed the `Makefile` for the `expand` example to follow the same formula as the others, and the generate command pointed to the incorrect include directory
- I have added the specific types to the function definition of `generateNodeLink` and `generateNodeSink` as these would not write the port number correctly surrounded by double quotes in the output Haskell files
- The `filterAcc` example did not generate the Haskell code correctly so I have made an adjustment on L192 (I was unsure if there should be two cases for `FilterAcc` and `Scan`, or the default case should be amended)
- There were unused imports as part of the `cabal test` definition - I have matched them with the executable