### PR TITLE
Changes to use Maybe for event fields 

### DIFF
--- a/examples/taxi/Taxi.hs
+++ b/examples/taxi/Taxi.hs
@@ -9,7 +9,7 @@ import Data.Time (UTCTime,NominalDiffTime)
 
 -- A solution to: http://www.debs2015.org/call-grand-challenge.html
 -- The winner was: https://vgulisano.files.wordpress.com/2015/06/debs2015gc_tr.pdf
--- Needs Parallel top-K ... see http://www.cs.yale.edu/homes/dongqu/PTA.pdf 
+-- Needs Parallel top-K ... see http://www.cs.yale.edu/homes/dongqu/PTA.pdf
 
 -- Define the types and data structures needed by the application
 -- Define the types and data structures needed by the application
@@ -27,7 +27,7 @@ data Payment_Type = Card | Cash
 
 type Medallion  = MD5Sum
 
-data Trip = Trip 
+data Trip = Trip
    { medallion         :: Medallion
    , hack_license      :: MD5Sum
    , pickup_datetime   :: UTCTime
@@ -44,7 +44,7 @@ data Trip = Trip
    , tolls_amount      :: Dollars
    , total_amount      :: Dollars}
       deriving (Eq, Ord, Show)
-  
+
 data Cell = Cell  -- the Cell in which the Taxi is located
    { clat  :: Int
    , clong :: Int}
@@ -52,7 +52,7 @@ data Cell = Cell  -- the Cell in which the Taxi is located
 
 instance Show Cell where
     show c = show (clat c) ++ "." ++ show (clong c)
-   
+
 data Journey  = Journey -- a taxi journey from one cell to another
    { start       :: Cell
    , end         :: Cell
@@ -100,14 +100,14 @@ inRangeQ2 = inRange 600 600
 
 --- Parse the input file --------------------------------------------------------------------------------------
 tripSource:: String -> Stream Trip -- parse input file into a Stream of Trips
-tripSource s = map (\t->E 0 (dropoff_datetime t) t) 
+tripSource s = map (\t -> Event 0 (Just (dropoff_datetime t)) (Just t))
                    (map stringsToTrip (map (Data.List.Split.splitOn ",") (lines s)))
 
 -- turns a line from the input file (already split into a list of fields) into a Trip datastructure
 stringsToTrip:: [String] -> Trip
 stringsToTrip [med,hack,pickupDateTime,dropoffDateTime,trip_time,trip_dist,pickup_long,pickup_lat,
                dropoff_long,dropoff_lat,pay_type,fare,sur,mta,tip,tolls,total] =
-   Trip med hack (read pickupDateTime) (read dropoffDateTime) (read trip_time) (read trip_dist) 
+   Trip med hack (read pickupDateTime) (read dropoffDateTime) (read trip_time) (read trip_dist)
                  (Location (read pickup_lat)  (read pickup_long))
                  (Location (read dropoff_lat) (read dropoff_long))
                  (if pay_type=="CRD" then Card else Cash)
@@ -117,27 +117,27 @@ stringsToTrip s = error ("error in input: " ++ (intercalate "," s))
 ----------------------------------------------------------------------------------------------------------------
 
 journeyChanges:: Stream ((UTCTime,UTCTime),[(Journey,Int)]) -> Stream ((UTCTime,UTCTime),[(Journey,Int)])
-journeyChanges s = streamFilterAcc (\acc h-> if (snd h==snd acc) then acc else h) (value $ head s) (\h acc->((snd h)/=(snd acc))) (tail s)
+journeyChanges (Event eid t (Just val):r) = streamFilterAcc (\acc h-> if (snd h==snd acc) then acc else h) val (\h acc->(snd h)/=(snd acc)) r
 
 --- removes consecutive repeated values from a stream, leaving only the changes
 changes:: Eq alpha=> Stream alpha -> Stream alpha
-changes s = streamFilterAcc (\acc h-> if (h==acc) then acc else h) (value $ head s) (\h acc->(h/=acc)) (tail s)
+changes (e@(Event eid t (Just val)):r) = e:(streamFilterAcc (\acc h-> h) val (\h acc-> h/=acc) r)
 
--- produces an ordered list of the i most frequent elements in the input list ---------------------------------               
+-- produces an ordered list of the i most frequent elements in the input list ---------------------------------
 mostFrequent:: Ord alpha => Int -> [alpha] -> [(alpha,Int)]
-mostFrequent i l = take i $ sortBy (\(k1,v1)(k2,v2)->compare v2 v1) 
+mostFrequent i l = take i $ sortBy (\(k1,v1)(k2,v2)->compare v2 v1)
                  $ Map.toList $ foldr (\e->Map.insertWith (+) e 1) Map.empty l
 
 ------------------------ Query 1 --------------------------------------------------------------------------------------
 type Q1Output = ((UTCTime,UTCTime),[(Journey,Int)])
 frequentRoutes:: Stream Trip -> Stream Q1Output
-frequentRoutes s = journeyChanges 
+frequentRoutes s = journeyChanges
                  $ streamWindowAggregate (slidingTime 1800) (\w->(let lj = last w in (pickupTime lj,dropoffTime lj),mostFrequent 10 w))
                  $ streamFilter (\j-> inRangeQ1 (start j) && inRangeQ1 (end j))
                  $ streamMap    tripToJourney s
 
 tripToJourney:: Trip -> Journey
-tripToJourney t = Journey{start=toCellQ1 (pickup t), end=toCellQ1 (dropoff t), pickupTime=(pickup_datetime t), dropoffTime=(dropoff_datetime t)}              
+tripToJourney t = Journey{start=toCellQ1 (pickup t), end=toCellQ1 (dropoff t), pickupTime=(pickup_datetime t), dropoffTime=(dropoff_datetime t)}
 
 -- to run Q1....
 mainQ1 = do contents <- readFile "sorteddata.csv"
@@ -158,23 +158,23 @@ main4 = do contents <- readFile "sorteddata.csv"
 
 q1map    = streamMap    tripToJourney
 q1filter = streamFilter (\j-> inRangeQ1 (start j) && inRangeQ1 (end j))
-q1window = streamWindow (slidingTime 1800) 
+q1window = streamWindow (slidingTime 1800)
 q1map2   = streamMap    (mostFrequent 10)
-           
+
 main5 = do contents <- readFile "sorteddata.csv"
            putStr $ show $ q1window $ q1filter $ q1map $ tripSource contents
-            
+
 main6 = do contents <- readFile "sorteddata.csv"
            putStr $ show $ q1map2 $ q1window $ q1filter $ q1map $ tripSource contents
 
 testQ1:: Show alpha => (Stream Trip -> alpha) -> IO()
-testQ1 f = do contents <- readFile "sorteddata.csv"  
-              putStr $ show $ f $ tripSource contents                  
-           
+testQ1 f = do contents <- readFile "sorteddata.csv"
+              putStr $ show $ f $ tripSource contents
+
 -- Query 2
 
 pickupHistory:: [(Trip,Journey)] -> Map.Map Cell [Trip]
-pickupHistory ts = foldr (\t->Map.insertWith (++) (start $ snd t) [(fst t)]) Map.empty ts 
+pickupHistory ts = foldr (\t->Map.insertWith (++) (start $ snd t) [(fst t)]) Map.empty ts
 
 newestPickup:: [(Trip,Journey)] -> Map.Map (Cell,Medallion) UTCTime
 newestPickup ts = foldr (\t->Map.insertWith (\newt existing->if newt>existing then newt else existing)
@@ -196,26 +196,26 @@ cellProfit:: [(Trip,Journey)] -> Map.Map Cell Dollars
 cellProfit tjs = Map.map profit $ pickupHistory tjs
 
 --"The number of empty taxis in an area is the sum of taxis that had a drop-off location in that area less than 30 minutes ago and had no following pickup yet."
- 
-taxisDroppedOffandNotPickedUp:: Map.Map (Cell,Medallion) UTCTime -> Map.Map (Cell,Medallion) UTCTime -> [(Trip,Journey)] -> [Cell] 
-taxisDroppedOffandNotPickedUp np od ts = map (\(t,j)->start j) $ filter (\(t,j)-> if Map.notMember (start j,medallion t) np  
+
+taxisDroppedOffandNotPickedUp:: Map.Map (Cell,Medallion) UTCTime -> Map.Map (Cell,Medallion) UTCTime -> [(Trip,Journey)] -> [Cell]
+taxisDroppedOffandNotPickedUp np od ts = map (\(t,j)->start j) $ filter (\(t,j)-> if Map.notMember (start j,medallion t) np
                                                                                   then True
-                                                                                  else np Map.! (start j,medallion t) < dropoff_datetime t) ts 
+                                                                                  else np Map.! (start j,medallion t) < dropoff_datetime t) ts
 
 emptyTaxisPerCell::  [(Trip,Journey)] -> Map.Map Cell Int
 emptyTaxisPerCell ts = foldl (\m c->Map.insertWith (+) c 1 m) Map.empty (taxisDroppedOffandNotPickedUp (newestPickup ts) (oldestDropoff ts) ts)
 
 allCells:: Int -> Int -> [Cell]
-allCells latMax longMax = [Cell lat long|lat<-[1..latMax],long<-[1..longMax]] 
+allCells latMax longMax = [Cell lat long|lat<-[1..latMax],long<-[1..longMax]]
 
 initCellMap:: Int -> Int -> a -> Map.Map Cell a
 initCellMap latMax longMax val = Map.fromList (zip (allCells latMax longMax) (repeat val))
-                           
+
 profitability:: Map.Map Cell Int -> Map.Map Cell Dollars -> Map.Map Cell Dollars
 profitability emptyTaxis cellProf = foldl (\m c->Map.insert c (Map.findWithDefault 0 c cellProf / fromIntegral (Map.findWithDefault 0 c emptyTaxis)) m) Map.empty (Map.keys emptyTaxis)
 
 --profitableCells:: Stream Trip -> Stream Q2Output
-profitableCells s = changes 
+profitableCells s = changes
                   $ streamWindowAggregate (slidingTime 1800)
                       (\es-> take 10
                            $ sortBy (\(k1,v1)(k2,v2)->compare v2 v1)
@@ -223,16 +223,16 @@ profitableCells s = changes
                            $ foldl (\m t->Map.insertWith (+) t 1 m) Map.empty es)
                   $ streamJoinW (slidingTime 900) (slidingTime 1800)
                                 (\a b->profitability (emptyTaxisPerCell b)(cellProfit a)) processedStream processedStream
-                       where processedStream = streamFilter (\(t,j)-> (inRangeQ2 $ start j) && (inRangeQ2 $ end j)) 
+                       where processedStream = streamFilter (\(t,j)-> (inRangeQ2 $ start j) && (inRangeQ2 $ end j))
                                              $ streamMap (\t-> (t,tripToJourney t)) s
 
 mainQ2 = do contents <- readFile "sorteddata.csv"
             putStr $ show $ profitableCells $ tripSource contents
-            
+
 ---------------- Tests of Q2 ------------------------------------------------------
-q2processedStream s = streamFilter (\(t,j)-> (inRangeQ2 $ start j) && (inRangeQ2 $ end j)) 
+q2processedStream s = streamFilter (\(t,j)-> (inRangeQ2 $ start j) && (inRangeQ2 $ end j))
                                       $ streamMap (\t-> (t,tripToJourney t)) s
-                                      
+
 q2Join s = streamJoinW (slidingTime 900) (slidingTime 1800)
                                 (\a b->profitability (emptyTaxisPerCell b)(cellProfit a)) s s
 
@@ -243,32 +243,31 @@ q2Agg s = streamWindowAggregate (slidingTime 1800)
                            $ foldl (\m t->Map.insertWith (+) t 1 m) Map.empty es) s
 
 q2TripSourceTest = do contents <- readFile "sorteddata.csv"
-                      putStr $ show $ take 50 $ tripSource contents 
+                      putStr $ show $ take 50 $ tripSource contents
 
 q2TripSourceTest2 = do contents <- readFile "sorteddata.csv"
-                       putStr $ show $ q2processedStream $ take 50 $ tripSource contents 
-                       
+                       putStr $ show $ q2processedStream $ take 50 $ tripSource contents
+
 q2TripSourceTest3 = do contents <- readFile "sorteddata.csv"
-                       putStr $ show $ q2Join $ q2processedStream $ take 50 $ tripSource contents 
-                      
+                       putStr $ show $ q2Join $ q2processedStream $ take 50 $ tripSource contents
+
 q2TripSourceTest4 = do contents <- readFile "sorteddata.csv"
-                       putStr $ show $ streamMap emptyTaxisPerCell $ streamWindow (slidingTime  900) $ q2processedStream $ take 50 $ tripSource contents 
-                       
+                       putStr $ show $ streamMap emptyTaxisPerCell $ streamWindow (slidingTime  900) $ q2processedStream $ take 50 $ tripSource contents
+
 q2TripSourceTest5 = do contents <- readFile "sorteddata.csv"
-                       putStr $ show $ streamMap cellProfit        $ streamWindow (slidingTime 1800) $ q2processedStream $ take 50 $ tripSource contents 
+                       putStr $ show $ streamMap cellProfit        $ streamWindow (slidingTime 1800) $ q2processedStream $ take 50 $ tripSource contents
 
 q2TripSourceTest6 = do contents <- readFile "sorteddata.csv"
-                       putStr $ show $ streamMap pickupHistory     $ streamWindow (slidingTime 1800) $ q2processedStream $ take 50 $ tripSource contents 
+                       putStr $ show $ streamMap pickupHistory     $ streamWindow (slidingTime 1800) $ q2processedStream $ take 50 $ tripSource contents
 
 q2TripSourceTest7 = do contents <- readFile "sorteddata.csv"
-                       putStr $ show $ q2Agg $ q2Join $ q2processedStream $ take 50 $ tripSource contents 
+                       putStr $ show $ q2Agg $ q2Join $ q2processedStream $ take 50 $ tripSource contents
 
 q2TripSourceTest8 = do contents <- readFile "sorteddata.csv"
-                       putStr $ show $ profitableCells $ take 50 $ tripSource contents 
+                       putStr $ show $ profitableCells $ take 50 $ tripSource contents
 
 q2TripSourceTest9 trips = do contents <- readFile "sorteddata.csv"
-                             putStr $ show $ profitableCells $ take trips $ tripSource contents  
+                             putStr $ show $ profitableCells $ take trips $ tripSource contents
 
 q2TripSourceTest10 = do contents <- readFile "sorteddata.csv"
                         putStr $ show $ length $ tripSource contents
-                        

--- a/examples/wearable/WearableExample.hs
+++ b/examples/wearable/WearableExample.hs
@@ -1,4 +1,4 @@
-module WearableUseCaseCloudCom2 where -- as WearableUseCaseCloudCom1, but keeps the timestamp in the header of the event
+module WearableUseCaseCloudCom2 where
 
 import Striot.FunctionalIoTtypes
 import Striot.FunctionalProcessing
@@ -82,12 +82,11 @@ jan_1_1900_time = UTCTime jan_1_1900_day 0 -- gives example time for the first e
 sampleDataGenerator :: Int -> UTCTime -> Int -> [Int] -> Stream PebbleMode60 -- Start Time -> Interval between events in ms ->
                                                                           -- List of random numbers -> Events
 sampleDataGenerator i start interval rands =
-    E
+         Event
             i
-            start
-            ( (rands !! 0, rands !! 1, rands !! 2)
-            , if rands !! 3 < 10 then 1 :: Int else 0 :: Int
-            )
+            (Just start)
+            (Just ((rands !! 0, rands !! 1, rands !! 2)
+            , if rands !! 3 < 10 then 1 :: Int else 0 :: Int))
         : sampleDataGenerator
               (i + 1)
               (addUTCTime (toEnum (interval * 10 ^ 9)) start)

--- a/src/Striot/FunctionalIoTtypes.hs
+++ b/src/Striot/FunctionalIoTtypes.hs
@@ -4,7 +4,9 @@ import Data.Time (UTCTime) -- http://two-wrongs.com/haskell-time-library-tutoria
 import GHC.Generics (Generic)
 import Data.Aeson
 
-data Event alpha     =  Event {eventId :: Int, time :: Maybe Timestamp, value :: Maybe alpha}
+data Event alpha = Event { eventId :: Int
+                         , time    :: Maybe Timestamp
+                         , value   :: Maybe alpha}
      deriving (Eq, Ord, Show, Read, Generic)
 
 type Timestamp       = UTCTime

--- a/src/Striot/FunctionalIoTtypes.hs
+++ b/src/Striot/FunctionalIoTtypes.hs
@@ -4,9 +4,7 @@ import Data.Time (UTCTime) -- http://two-wrongs.com/haskell-time-library-tutoria
 import GHC.Generics (Generic)
 import Data.Aeson
 
-data Event alpha     =  E {id :: Int, time :: Timestamp, value :: alpha} |
-                        T {id :: Int, time :: Timestamp                } |
-                        V {id :: Int,                    value :: alpha}
+data Event alpha     =  Event {eventId :: Int, time :: Maybe Timestamp, value :: Maybe alpha}
      deriving (Eq, Ord, Show, Read, Generic)
 
 type Timestamp       = UTCTime
@@ -18,11 +16,9 @@ instance (ToJSON alpha) => ToJSON (Event alpha) where
     toEncoding = genericToEncoding defaultOptions
 
 dataEvent :: Event alpha -> Bool
-dataEvent (E id t v) = True
-dataEvent (V id v  ) = True
-dataEvent (T id t  ) = False
+dataEvent (Event eid t (Just v)) = True
+dataEvent (Event eid t Nothing)  = False
 
 timedEvent :: Event alpha -> Bool
-timedEvent (E id t v) = True
-timedEvent (V id v  ) = False
-timedEvent (T id t  ) = True
+timedEvent (Event eid (Just t) v) = True
+timedEvent (Event eid Nothing  v) = False

--- a/src/Striot/Nodes.hs
+++ b/src/Striot/Nodes.hs
@@ -115,7 +115,7 @@ readListFromSource = go 0
         msg x = do
             now     <- getCurrentTime
             payload <- pay
-            return (E x now payload)
+            return (Event x (Just now) (Just payload))
 
 
 {- processSocket is a wrapper function that handles concurrently


### PR DESCRIPTION
@PaulWatson9994's changes - resolves #22. This includes the following:

- Change to the `Event` data type to use `Maybe` types for `time` and `value` fields. The constructor is now `Event` rather than `E`, `T`, or `V`
- Renaming of `id` field to `eventId`, to prevent shadowing of `Prelude.id` - fixes #3
- Re-definition of the various functional operators for the new `Event` data type, along with simplification of windowing operations
- Update to [Taxi.hs](https://github.com/striot/striot/compare/master...adam-cattermole:events-maybe-rewrite?expand=1#diff-518916fe5318006d09a105f6c338e201) and [WearableExample.hs](https://github.com/striot/striot/compare/master...adam-cattermole:events-maybe-rewrite?expand=1#diff-aae4c297ce6f625cdcdef49b001e59d5) - For the latter, (CRLF has been replaced by LF), the main change is use of data constructor within `sampleDataGenerator`, L82