### PR TITLE
CompileIoT: remove src function type signature

### DIFF
--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -157,7 +157,7 @@ connectNodeId sg parts cuts = let
     in map fst destGs
 
 generateSrcFn :: StreamGraph -> String
-generateSrcFn sg = "src1 :: IO String\nsrc1 = " ++
+generateSrcFn sg = "src1 = " ++
     (intercalate "\n" $ parameters $ head $ vertexList sg) ++ "\n"
 
 generateSinkFn:: StreamGraph -> String


### PR DESCRIPTION
The type signature was fixed to "IO String", which forced the Stream
type to be "String". However we will want to pass around other types
(like Journey for Taxi). Removing the type signature provides the
needed flexibility.