### PR TITLE
generateCodeFromVertex: anon function wrappers

### DIFF
--- a/examples/expand/generate.hs
+++ b/examples/expand/generate.hs
@@ -27,11 +27,11 @@ source = "do\n\
 \            randomWords = " ++ (show randomWords)
 
 
-v1 = StreamVertex 1 Source [source] "String"
-v2 = StreamVertex 2 Map    ["filter (('#'==).head) . words"] "[String]"
+v1 = StreamVertex 1 Source [source]                                "String"
+v2 = StreamVertex 2 Map    ["(filter (('#'==).head) . words)","s"] "[String]"
 
-v5 = StreamVertex 5 Expand [""]                 "[String]"
-v6 = StreamVertex 6 Sink   ["mapM_ print"] "String"
+v5 = StreamVertex 5 Expand ["s"]                                   "[String]"
+v6 = StreamVertex 6 Sink   ["mapM_ print"]                         "String"
 
 mergeEx :: StreamGraph
 mergeEx = path [v1, v2, v5, v6]

--- a/examples/filter/generate.hs
+++ b/examples/filter/generate.hs
@@ -16,9 +16,9 @@ source = "do\n\
 \        return s"
 
 v1 = StreamVertex 1 Source [source]                         "String"
-v2 = StreamVertex 2 Map    ["Prelude.id"]                   "String"
-v3 = StreamVertex 3 Filter ["(\\s -> (read s :: Int) > 5)"] "String"
-v4 = StreamVertex 4 Window ["chop 1"] "[String]"
+v2 = StreamVertex 2 Map    ["id", "s"]                   "String"
+v3 = StreamVertex 3 Filter ["(\\i -> (read i :: Int) > 5)", "s"] "String"
+v4 = StreamVertex 4 Window ["(chop 1)", "s"] "[String]"
 v5 = StreamVertex 5 Sink   ["mapM_ $ putStrLn . (\"receiving \"++) . show . value"] "[String]"
 
 mergeEx :: StreamGraph

--- a/examples/filterAcc/generate.hs
+++ b/examples/filterAcc/generate.hs
@@ -16,9 +16,9 @@ source = "do\n\
 \        return s"
 
 v1 = StreamVertex 1 Source    [source]                                                 "String"
-v2 = StreamVertex 2 Map       ["Prelude.id"]                                           "String"
-v3 = StreamVertex 3 FilterAcc ["(\\_ s -> s)", "\"0\"", "(/=)"]                        "String"
-v4 = StreamVertex 4 Window    ["chop 1"]                                               "[String]"
+v2 = StreamVertex 2 Map       ["id", "s"]                                              "String"
+v3 = StreamVertex 3 FilterAcc ["(\\_ e -> e)", "\"0\"", "(/=)", "s"]                   "String"
+v4 = StreamVertex 4 Window    ["(chop 1)", "s"]                                          "[String]"
 v5 = StreamVertex 5 Sink      ["mapM_ $ putStrLn . (\"receiving \"++) . show . value"] "[String]"
 
 mergeEx :: StreamGraph

--- a/examples/join/generate.hs
+++ b/examples/join/generate.hs
@@ -9,11 +9,11 @@ source x = "do\n\
 \    putStrLn \"sending '"++x++"'\"\n\
 \    return \""++x++"\""
 
-v1 = StreamVertex 1 Source [source "foo"]              "String"
-v2 = StreamVertex 2 Map    ["Prelude.id"]              "String"
-v3 = StreamVertex 3 Source [source "bar"]              "String"
-v4 = StreamVertex 4 Map    ["Prelude.id"]              "String"
-v5 = StreamVertex 5 Join   ["[n1,n2]"]                 "String"
+v1 = StreamVertex 1 Source [source "foo"]  "String"
+v2 = StreamVertex 2 Map    ["id", "s"]     "String"
+v3 = StreamVertex 3 Source [source "bar"]  "String"
+v4 = StreamVertex 4 Map    ["id", "s"]     "String"
+v5 = StreamVertex 5 Join   ["s1", "s2"]    "String"
 v6 = StreamVertex 6 Sink   ["mapM_ print"] "(String, String)"
 
 joinEx :: StreamGraph

--- a/examples/merge/generate.hs
+++ b/examples/merge/generate.hs
@@ -14,11 +14,11 @@ source x = "do\n\
 \    return \""++x++"\""
 
 
-v1 = StreamVertex 1 Source [source "foo"]              "String"
-v2 = StreamVertex 2 Map    ["Prelude.id"]              "String"
-v3 = StreamVertex 3 Source [source "bar"]              "String"
-v4 = StreamVertex 4 Map    ["Prelude.id"]              "String"
-v5 = StreamVertex 5 Merge  ["[n1,n2]"]                 "String"
+v1 = StreamVertex 1 Source [source "foo"]  "String"
+v2 = StreamVertex 2 Map    ["id", "s"]     "String"
+v3 = StreamVertex 3 Source [source "bar"]  "String"
+v4 = StreamVertex 4 Map    ["id", "s"]     "String"
+v5 = StreamVertex 5 Merge  ["[s1,s2]"]     "String"
 v6 = StreamVertex 6 Sink   ["mapM_ print"] "String"
 
 mergeEx :: StreamGraph

--- a/examples/pipeline/generate.hs
+++ b/examples/pipeline/generate.hs
@@ -10,11 +10,11 @@ imports = ["Striot.FunctionalIoTtypes", "Striot.FunctionalProcessing", "Striot.N
 
 pipeEx :: StreamGraph
 pipeEx = path [ StreamVertex 1 Source ["do\n    threadDelay (1000*1000)\n    return \"Hello from Client!\""] "String"
-              , StreamVertex 2 Map    ["\\st->st++st"]                                                   "String"
-              , StreamVertex 3 Map    ["\\st->reverse st"]                                               "String"
-              , StreamVertex 4 Map    ["\\st->\"Incoming Message at Server: \" ++ st"]                   "String"
-              , StreamVertex 5 Window ["(chop 2)"]                                                       "String"
-              , StreamVertex 6 Sink   ["mapM_ print"]                                        "[String]"
+              , StreamVertex 2 Map    ["(\\st->st++st)", "s"]                                                "String"
+              , StreamVertex 3 Map    ["reverse", "s"]                                                       "String"
+              , StreamVertex 4 Map    ["(\\st->\"Incoming Message at Server: \" ++ st)", "s"]                "String"
+              , StreamVertex 5 Window ["(chop 2)", "s"]                                                      "String"
+              , StreamVertex 6 Sink   ["mapM_ print"]                                                        "[String]"
               ]
 
 partEx = generateCode pipeEx [[1,2],[3],[4,5,6]] imports

--- a/examples/scan/generate.hs
+++ b/examples/scan/generate.hs
@@ -13,9 +13,9 @@ source x = "do\n\
 \    return \""++x++"\""
 
 v1 = StreamVertex 1 Source [source "foo"] "String"
-v2 = StreamVertex 2 Map    ["Prelude.id"] "String"
+v2 = StreamVertex 2 Map    ["id", "s"] "String"
 
-v5 = StreamVertex 5 Scan   ["(\\old _ -> old + 1)", "0"] "String"
+v5 = StreamVertex 5 Scan   ["(\\old _ -> old + 1)", "0", "s"] "String"
 v6 = StreamVertex 6 Sink   ["mapM_ print"] "Int"
 
 scanEx :: StreamGraph


### PR DESCRIPTION
wrap each operator expression in an anonymous function with the variable
labelled 's'. Therefore, the arguments for the operator can reference the
incoming stream item as 's'. (the exception being "merge", which receives
two arguments, 's1' and 's2')

This permits the other arguments to the operator referencing the incoming
stream. For example, the following pattern is now possible

	streamFilterAccfn ac filter (head s) (tail s)

More generally refactor generateCodeFromVertex and remove several special
cases.