### PR TITLE
Remove strict boundaries on network package, and unneeded STM package

### DIFF
--- a/containers/striot-base/Dockerfile
+++ b/containers/striot-base/Dockerfile
@@ -8,7 +8,6 @@ RUN cabal update && \
     cabal install \
     network \
     split \
-    stm \
     HTF \
     aeson \
     unagi-chan \

--- a/src/Striot/Nodes.hs
+++ b/src/Striot/Nodes.hs
@@ -7,15 +7,14 @@ module Striot.Nodes ( nodeSink
                     ) where
 
 import           Control.Concurrent
-import           Control.Concurrent.STM
 import           Control.Concurrent.Chan.Unagi as U
-import           Control.Monad              (forever, when)
+import           Control.Monad                 (forever, when)
 import           Data.Aeson
-import qualified Data.ByteString            as B
-import qualified Data.ByteString.Char8      as BC (putStrLn)
-import qualified Data.ByteString.Lazy.Char8 as BLC (hPutStrLn, putStrLn)
+import qualified Data.ByteString                as B
+import qualified Data.ByteString.Char8          as BC (putStrLn)
+import qualified Data.ByteString.Lazy.Char8     as BLC (hPutStrLn, putStrLn)
 import           Data.Maybe
-import           Data.Time                  (getCurrentTime)
+import           Data.Time                      (getCurrentTime)
 import           Network.Socket
 import           Striot.FunctionalIoTtypes
 import           System.IO
@@ -263,8 +262,8 @@ createSocket host port hints = do
     sock <- getSocket addr
     return (sock, addr)
   where
-    resolve host port hints = do
-        addr:_ <- getAddrInfo (Just hints) (isHost host) (Just port)
+    resolve host' port' hints' = do
+        addr:_ <- getAddrInfo (Just hints') (isHost host') (Just port')
         return addr
     getSocket addr = socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
     isHost h

--- a/striot.cabal
+++ b/striot.cabal
@@ -19,7 +19,7 @@ library
   exposed-modules:     Striot.FunctionalIoTtypes, Striot.FunctionalProcessing, Striot.Nodes, Striot.CompileIoT
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.9 && <4.10, containers >=0.5 && <0.6, split >=0.2 && <0.3, time >=1.6 && <1.7, network >=2.6 && <2.8, stm >=2.4 && <2.5, HTF, aeson, bytestring, unagi-chan, algebraic-graphs >= 0.1
+  build-depends:       base >=4.9 && <4.10, containers >=0.5 && <0.6, split >=0.2 && <0.3, time >=1.6 && <1.7, network, HTF, aeson, bytestring, unagi-chan, algebraic-graphs >= 0.1
   hs-source-dirs:      src
   default-language:    Haskell98
 
@@ -27,5 +27,5 @@ test-suite test-striot
   hs-source-dirs:      src
   type:                exitcode-stdio-1.0
   Main-is:             TestMain.hs
-  build-depends:       base >=4.9 && <4.10, containers >=0.5 && <0.6, split >=0.2 && <0.3, time >=1.6 && <1.7, network >=2.6 && <2.7, stm >=2.4 && <2.5, HTF, aeson, bytestring, unagi-chan, algebraic-graphs >= 0.1
+  build-depends:       base >=4.9 && <4.10, containers >=0.5 && <0.6, split >=0.2 && <0.3, time >=1.6 && <1.7, network, HTF, aeson, bytestring, unagi-chan, algebraic-graphs >= 0.1
   Default-language:    Haskell98


### PR DESCRIPTION
The `striot-base` image no longer builds, as the latest version of `network` and `stm` lie outside of the dependency range. I have removed the strict boundary, as I do not believe any changes to the `network` package should directly affect our solution without seeing deprecation warnings beforehand.

As we no longer use the STM package in `Nodes.hs`, it has been removed.

Very minor refactor to `Nodes.hs`