### PR TITLE
Make adjustments for GHC 8.4

### DIFF
--- a/containers/striot-base/Dockerfile
+++ b/containers/striot-base/Dockerfile
@@ -1,20 +1,22 @@
 # Run from a pre-built Haskell container
-FROM haskell:8.0.1
+FROM haskell:8.4
 
 RUN apt-get update && apt-get upgrade -y
 
-# Install the network stack from Cabal as this isn't part of the core
-RUN cabal update && \
-    cabal install \
-    network \
-    split \
-    HTF \
-    aeson \
-    unagi-chan \
-    algebraic-graphs
-
-COPY striot /opt/striot
+# Copy cabal file and license
+COPY striot/striot.cabal striot/LICENSE /opt/striot/
 
 WORKDIR /opt/striot
+
+# Install all dependencies defined in cabal file - we must install happy
+# separately for HTF, as the image has a bootstrapping problem
+RUN cabal update && \
+    cabal install happy && \
+    cabal install --only-dependencies
+
+# Copy over source code in a separate layer, ensuring above is cached if
+# cabal file does not change
+COPY striot/src /opt/striot/src
+
 RUN cabal build && \
     cabal install

--- a/striot.cabal
+++ b/striot.cabal
@@ -19,13 +19,13 @@ library
   exposed-modules:     Striot.FunctionalIoTtypes, Striot.FunctionalProcessing, Striot.Nodes, Striot.CompileIoT
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.9 && <4.10, containers >=0.5 && <0.6, split >=0.2 && <0.3, time >=1.6 && <1.7, network, HTF, aeson, bytestring, unagi-chan, algebraic-graphs >= 0.1
+  build-depends:       base, containers, split, time, network, HTF, aeson, bytestring, unagi-chan, algebraic-graphs
   hs-source-dirs:      src
-  default-language:    Haskell98
+  default-language:    Haskell2010
 
 test-suite test-striot
   hs-source-dirs:      src
   type:                exitcode-stdio-1.0
   Main-is:             TestMain.hs
-  build-depends:       base >=4.9 && <4.10, containers >=0.5 && <0.6, split >=0.2 && <0.3, time >=1.6 && <1.7, network, HTF, aeson, bytestring, unagi-chan, algebraic-graphs >= 0.1
-  Default-language:    Haskell98
+  build-depends:       base, containers, split, time, network, HTF, aeson, bytestring, unagi-chan, algebraic-graphs
+  Default-language:    Haskell2010

--- a/striot.cabal
+++ b/striot.cabal
@@ -19,7 +19,7 @@ library
   exposed-modules:     Striot.FunctionalIoTtypes, Striot.FunctionalProcessing, Striot.Nodes, Striot.CompileIoT
   -- other-modules:
   -- other-extensions:
-  build-depends:       base, containers, split, time, network, HTF, aeson, bytestring, unagi-chan, algebraic-graphs
+  build-depends:       base >=4.9, containers >=0.5, split >=0.2, time >=1.6, network >=2.7.0.0, HTF, aeson, bytestring >=0.9.2, unagi-chan >=0.4.1.0, algebraic-graphs >=0.1
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -27,5 +27,5 @@ test-suite test-striot
   hs-source-dirs:      src
   type:                exitcode-stdio-1.0
   Main-is:             TestMain.hs
-  build-depends:       base, containers, split, time, network, HTF, aeson, bytestring, unagi-chan, algebraic-graphs
+  build-depends:       base >=4.9, containers >=0.5, split >=0.2, time >=1.6, network >=2.7.0.0, HTF, aeson, bytestring >=0.9.2, unagi-chan >=0.4.1.0, algebraic-graphs >=0.1
   Default-language:    Haskell2010

--- a/striot.cabal
+++ b/striot.cabal
@@ -28,4 +28,5 @@ test-suite test-striot
   type:                exitcode-stdio-1.0
   Main-is:             TestMain.hs
   build-depends:       base >=4.9, containers >=0.5, split >=0.2, time >=1.6, network >=2.7.0.0, HTF, aeson, bytestring >=0.9.2, unagi-chan >=0.4.1.0, algebraic-graphs >=0.1
+  other-modules:       Striot.CompileIoT, Striot.FunctionalIoTtypes, Striot.FunctionalProcessing, Striot.Nodes, VizGraph
   Default-language:    Haskell2010


### PR DESCRIPTION
- Remove strict checks on cabal dependencies - I am not sure if this is really the best move forwards, there may be some dependencies we wish to keep at a particular version. This does have the benefit however of allowing us to build on many different GHC versions without conflicts.
- Dockerfile should now take changes to the source code / cabal file into account when building the image - all dependencies will be installed from the cabal file
- `Nodes.hs` has had newly introduced warnings fixed
- Changed language from `Haskell98` -> `Haskell2010`

Closes: #33