### PR TITLE
Add QuickCheck property for streamScan behaviour

### DIFF
--- a/src/Striot/FunctionalProcessing.hs
+++ b/src/Striot/FunctionalProcessing.hs
@@ -151,16 +151,16 @@ streamFilterAcc accfn acc ff (e@(Event _ _ Nothing ):r)             = e:(streamF
 
 -- Stream map with accumulating parameter
 streamScan:: (beta -> alpha -> beta) -> beta -> Stream alpha -> Stream beta
-streamScan mf acc []                        = []
-streamScan mf acc ((Event id t (Just v)):r) = (Event id t        (Just newacc)):(streamScan mf newacc r) where newacc = mf acc v
-streamScan mf acc ((Event id t Nothing ):r) = (Event id t        Nothing      ):(streamScan mf acc    r) -- allow events without data to pass through
+streamScan _  _   []                       = []
+streamScan mf acc (Event eid t (Just v):r) = Event eid t (Just newacc):streamScan mf newacc r where newacc = mf acc v
+streamScan mf acc (Event eid t Nothing :r) = Event eid t Nothing      :streamScan mf acc    r -- allow events without data to pass through
 
 -- Map a Stream to a set of events
 streamExpand :: Stream [alpha] -> Stream alpha
 streamExpand s = concatMap eventExpand s
       where eventExpand :: Event [alpha] -> [Event alpha]
-            eventExpand (Event id t (Just v)) = map (\nv->Event id t (Just nv)) v
-            eventExpand (Event id t Nothing ) = [Event id t Nothing]
+            eventExpand (Event eid t (Just v)) = map (\nv->Event eid t (Just nv)) v
+            eventExpand (Event eid t Nothing ) = [Event eid t Nothing]
 
 --streamSource :: Stream alpha -> Stream alpha
 --streamSource ss = ss

--- a/src/Striot/FunctionalProcessing.hs
+++ b/src/Striot/FunctionalProcessing.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -F -pgmF htfpp #-}
+
 module Striot.FunctionalProcessing ( streamFilter
                                    , streamMap
                                    , streamWindow
@@ -19,10 +21,13 @@ module Striot.FunctionalProcessing ( streamFilter
                                    , EventFilter
                                    , EventMap
                                    , JoinFilter
-                                   , JoinMap) where
+                                   , JoinMap
+
+                                   , htf_thisModulesTests) where
 
 import Striot.FunctionalIoTtypes
 import Data.Time (UTCTime,addUTCTime,diffUTCTime,NominalDiffTime)
+import Test.Framework
 
 -- Define the Basic IoT Stream Functions
 
@@ -154,6 +159,15 @@ streamScan:: (beta -> alpha -> beta) -> beta -> Stream alpha -> Stream beta
 streamScan _  _   []                       = []
 streamScan mf acc (Event eid t (Just v):r) = Event eid t (Just newacc):streamScan mf newacc r where newacc = mf acc v
 streamScan mf acc (Event eid t Nothing :r) = Event eid t Nothing      :streamScan mf acc    r -- allow events without data to pass through
+
+instance Arbitrary a => Arbitrary (Event a) where
+    arbitrary = do
+        eid <- arbitrary
+        i <- arbitrary
+        return $ Event eid Nothing (Just i)
+
+prop_streamScan_samelength :: Stream Int -> Bool
+prop_streamScan_samelength s = length s == length (streamScan (\_ x-> x) 0 s)
 
 -- Map a Stream to a set of events
 streamExpand :: Stream [alpha] -> Stream alpha

--- a/src/Striot/FunctionalProcessing.hs
+++ b/src/Striot/FunctionalProcessing.hs
@@ -1,4 +1,4 @@
-module Striot.FunctionalProcessing (  streamFilter
+module Striot.FunctionalProcessing ( streamFilter
                                    , streamMap
                                    , streamWindow
                                    , streamWindowAggregate
@@ -151,7 +151,7 @@ streamFilterAcc accfn acc ff (e@(Event _ _ Nothing ):r)             = e:(streamF
 
 -- Stream map with accumulating parameter
 streamScan:: (beta -> alpha -> beta) -> beta -> Stream alpha -> Stream beta
-streamScan mf acc []                        = (Event 0  Nothing  (Just acc   )):[]
+streamScan mf acc []                        = []
 streamScan mf acc ((Event id t (Just v)):r) = (Event id t        (Just newacc)):(streamScan mf newacc r) where newacc = mf acc v
 streamScan mf acc ((Event id t Nothing ):r) = (Event id t        Nothing      ):(streamScan mf acc    r) -- allow events without data to pass through
 

--- a/src/TestMain.hs
+++ b/src/TestMain.hs
@@ -7,7 +7,7 @@ import {-@ HTF_TESTS @-} Striot.CompileIoT
 import {-@ HTF_TESTS @-} VizGraph
 
 import Striot.FunctionalIoTtypes
-import Striot.FunctionalProcessing
+import {-@ HTF_TESTS @-} Striot.FunctionalProcessing
 import Striot.Nodes
 
 main = htfMain htf_importedTests


### PR DESCRIPTION
**NOTE: I've based this on top of #39 - this should probably not be merged
until #39 is, and may need rebasing afterwards too.**

Write a QuickCheck property to ensure that the output stream from
streamScan is the same length as the input. This would catch the bug
that was fixed in #39.

This required writing an Arbitrary instance for Event; this is defined
adjacent to the above test in FunctionalProcessing but future work may
move it to FunctionalIoTtypes (adjacent to the Event definition) and
possibly export it.

Make necessary adjustments to FunctionalProcessing for HTF and hook
the new QuickCheck property into src/TestMain: this ensures it's
collected and tested by "cabal test".