### PR TITLE
CompileIoT: add output type field to StreamVertex type

### DIFF
--- a/examples/expand/generate.hs
+++ b/examples/expand/generate.hs
@@ -27,11 +27,11 @@ source = "do\n\
 \            randomWords = " ++ (show randomWords)
 
 
-v1 = StreamVertex 1 Source [source]                                "String"
-v2 = StreamVertex 2 Map    ["(filter (('#'==).head) . words)","s"] "[String]"
+v1 = StreamVertex 1 Source [source]                                "String" "String"
+v2 = StreamVertex 2 Map    ["(filter (('#'==).head) . words)","s"] "String" "[String]"
 
-v5 = StreamVertex 5 Expand ["s"]                                   "[String]"
-v6 = StreamVertex 6 Sink   ["mapM_ print"]                         "String"
+v5 = StreamVertex 5 Expand ["s"]                                   "[String]" "String"
+v6 = StreamVertex 6 Sink   ["mapM_ print"]                         "String" "String"
 
 mergeEx :: StreamGraph
 mergeEx = path [v1, v2, v5, v6]

--- a/examples/filter/generate.hs
+++ b/examples/filter/generate.hs
@@ -15,11 +15,11 @@ source = "do\n\
 \        putStrLn $ \"client sending \" ++ s\n\
 \        return s"
 
-v1 = StreamVertex 1 Source [source]                         "String"
-v2 = StreamVertex 2 Map    ["id", "s"]                   "String"
-v3 = StreamVertex 3 Filter ["(\\i -> (read i :: Int) > 5)", "s"] "String"
-v4 = StreamVertex 4 Window ["(chop 1)", "s"] "[String]"
-v5 = StreamVertex 5 Sink   ["mapM_ $ putStrLn . (\"receiving \"++) . show . value"] "[String]"
+v1 = StreamVertex 1 Source [source]                         "String" "String"
+v2 = StreamVertex 2 Map    ["id", "s"]                   "String" "String"
+v3 = StreamVertex 3 Filter ["(\\i -> (read i :: Int) > 5)", "s"] "String" "String"
+v4 = StreamVertex 4 Window ["(chop 1)", "s"] "String" "[String]"
+v5 = StreamVertex 5 Sink   ["mapM_ $ putStrLn . (\"receiving \"++) . show . value"] "[String]" "IO ()"
 
 mergeEx :: StreamGraph
 mergeEx = path [v1, v2, v3, v4, v5]

--- a/examples/filterAcc/generate.hs
+++ b/examples/filterAcc/generate.hs
@@ -15,11 +15,11 @@ source = "do\n\
 \        putStrLn $ \"client sending \" ++ s\n\
 \        return s"
 
-v1 = StreamVertex 1 Source    [source]                                                 "String"
-v2 = StreamVertex 2 Map       ["id", "s"]                                              "String"
-v3 = StreamVertex 3 FilterAcc ["(\\_ e -> e)", "\"0\"", "(/=)", "s"]                   "String"
-v4 = StreamVertex 4 Window    ["(chop 1)", "s"]                                          "[String]"
-v5 = StreamVertex 5 Sink      ["mapM_ $ putStrLn . (\"receiving \"++) . show . value"] "[String]"
+v1 = StreamVertex 1 Source    [source]                                                 "String" "String"
+v2 = StreamVertex 2 Map       ["id", "s"]                                              "String" "String"
+v3 = StreamVertex 3 FilterAcc ["(\\_ e -> e)", "\"0\"", "(/=)", "s"]                   "String" "String"
+v4 = StreamVertex 4 Window    ["(chop 1)", "s"]                                        "String" "[String]"
+v5 = StreamVertex 5 Sink      ["mapM_ $ putStrLn . (\"receiving \"++) . show . value"] "[String]" "IO ()"
 
 mergeEx :: StreamGraph
 mergeEx = path [v1, v2, v3, v4, v5]

--- a/examples/join/generate.hs
+++ b/examples/join/generate.hs
@@ -9,12 +9,12 @@ source x = "do\n\
 \    putStrLn \"sending '"++x++"'\"\n\
 \    return \""++x++"\""
 
-v1 = StreamVertex 1 Source [source "foo"]  "String"
-v2 = StreamVertex 2 Map    ["id", "s"]     "String"
-v3 = StreamVertex 3 Source [source "bar"]  "String"
-v4 = StreamVertex 4 Map    ["id", "s"]     "String"
-v5 = StreamVertex 5 Join   ["s1", "s2"]    "String"
-v6 = StreamVertex 6 Sink   ["mapM_ print"] "(String, String)"
+v1 = StreamVertex 1 Source [source "foo"]  "String" "String"
+v2 = StreamVertex 2 Map    ["id", "s"]     "String" "String"
+v3 = StreamVertex 3 Source [source "bar"]  "String" "String"
+v4 = StreamVertex 4 Map    ["id", "s"]     "String" "String"
+v5 = StreamVertex 5 Join   ["s1", "s2"]    "String" "(String, String)"
+v6 = StreamVertex 6 Sink   ["mapM_ print"] "(String, String)" "IO ()"
 
 joinEx :: StreamGraph
 joinEx = overlay (path [v3, v4, v5]) $ path [v1, v2, v5, v6]

--- a/examples/merge/generate.hs
+++ b/examples/merge/generate.hs
@@ -14,12 +14,12 @@ source x = "do\n\
 \    return \""++x++"\""
 
 
-v1 = StreamVertex 1 Source [source "foo"]  "String"
-v2 = StreamVertex 2 Map    ["id", "s"]     "String"
-v3 = StreamVertex 3 Source [source "bar"]  "String"
-v4 = StreamVertex 4 Map    ["id", "s"]     "String"
-v5 = StreamVertex 5 Merge  ["[s1,s2]"]     "String"
-v6 = StreamVertex 6 Sink   ["mapM_ print"] "String"
+v1 = StreamVertex 1 Source [source "foo"]  "String" "String"
+v2 = StreamVertex 2 Map    ["id", "s"]     "String" "String"
+v3 = StreamVertex 3 Source [source "bar"]  "String" "String"
+v4 = StreamVertex 4 Map    ["id", "s"]     "String" "String"
+v5 = StreamVertex 5 Merge  ["[s1,s2]"]     "String" "String" -- XXX: we lie about the input type here, because the generated function has split-out arguments
+v6 = StreamVertex 6 Sink   ["mapM_ print"] "String" "IO ()"
 
 mergeEx :: StreamGraph
 mergeEx = overlay (path [v3, v4, v5]) $ path [v1, v2, v5, v6]

--- a/examples/pipeline/generate.hs
+++ b/examples/pipeline/generate.hs
@@ -9,13 +9,14 @@ import System.FilePath --(</>)
 imports = ["Striot.FunctionalIoTtypes", "Striot.FunctionalProcessing", "Striot.Nodes", "Control.Concurrent"]
 
 pipeEx :: StreamGraph
-pipeEx = path [ StreamVertex 1 Source ["do\n    threadDelay (1000*1000)\n    return \"Hello from Client!\""] "String"
-              , StreamVertex 2 Map    ["(\\st->st++st)", "s"]                                                "String"
-              , StreamVertex 3 Map    ["reverse", "s"]                                                       "String"
-              , StreamVertex 4 Map    ["(\\st->\"Incoming Message at Server: \" ++ st)", "s"]                "String"
-              , StreamVertex 5 Window ["(chop 2)", "s"]                                                      "String"
-              , StreamVertex 6 Sink   ["mapM_ print"]                                                        "[String]"
-              ]
+pipeEx = path
+    [ StreamVertex 1 Source ["do\n    threadDelay (1000*1000)\n    return \"Hello from Client!\""] "String" "String"
+    , StreamVertex 2 Map    ["(\\st->st++st)", "s"]                                                "String" "String"
+    , StreamVertex 3 Map    ["reverse", "s"]                                                       "String" "String"
+    , StreamVertex 4 Map    ["(\\st->\"Incoming Message at Server: \" ++ st)", "s"]                "String" "String"
+    , StreamVertex 5 Window ["(chop 2)", "s"]                                                      "String" "[String]"
+    , StreamVertex 6 Sink   ["mapM_ print"]                                                        "[String]" "IO ()"
+    ]
 
 partEx = generateCode pipeEx [[1,2],[3],[4,5,6]] imports
 

--- a/examples/scan/generate.hs
+++ b/examples/scan/generate.hs
@@ -12,11 +12,11 @@ source x = "do\n\
 \    putStrLn \"sending '"++x++"'\"\n\
 \    return \""++x++"\""
 
-v1 = StreamVertex 1 Source [source "foo"] "String"
-v2 = StreamVertex 2 Map    ["id", "s"] "String"
+v1 = StreamVertex 1 Source [source "foo"] "String" "String"
+v2 = StreamVertex 2 Map    ["id", "s"] "String" "String"
 
-v5 = StreamVertex 5 Scan   ["(\\old _ -> old + 1)", "0", "s"] "String"
-v6 = StreamVertex 6 Sink   ["mapM_ print"] "Int"
+v5 = StreamVertex 5 Scan   ["(\\old _ -> old + 1)", "0", "s"] "String" "Int"
+v6 = StreamVertex 6 Sink   ["mapM_ print"] "Int" "IO ()"
 
 scanEx :: StreamGraph
 scanEx = path [v1, v2, v5, v6]

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -43,10 +43,11 @@ data StreamVertex = StreamVertex
     , operator   :: StreamOperator
     , parameters :: [String] -- XXX strings of code. From CompileIoT. Variable length e.g.FilterAcc takes 3 (?)
     , intype     :: String
+    , outtype    :: String
     } deriving (Eq)
 
 instance Ord StreamVertex where
-    compare (StreamVertex x _ _ _) (StreamVertex y _ _ _) = compare x y
+    compare (StreamVertex x _ _ _ _) (StreamVertex y _ _ _ _) = compare x y
 
 instance Show StreamVertex where
     show v = intercalate " " $ ((show . operator) v) : ((map (\s->"("++s++")")) . parameters) v
@@ -126,7 +127,7 @@ generateCodeFromStreamGraph imports parts cuts (partId,sg) = intercalate "\n" $
     nodeFn sg] where
         nodeId = "-- node"++(show partId)
         padding = "    "
-        sgTypeSignature = "streamGraphFn ::"++(concat $ take valence $ repeat $ " Stream "++inType++" ->")++" Stream "++outType
+        sgTypeSignature = "streamGraphFn ::"++(concat $ take valence $ repeat $ " Stream "++(inType sg)++" ->")++" Stream "++(outType sg)
         sgIntro = "streamGraphFn "++sgArgs++" = let"
         sgArgs = unwords $ map (('n':).show) [1..valence]
         imports' = (map ("import "++) imports) ++ ["\n"]
@@ -141,10 +142,40 @@ generateCodeFromStreamGraph imports parts cuts (partId,sg) = intercalate "\n" $
             NodeSource -> generateSrcFn sg
             NodeLink   -> ""
             NodeSink   -> generateSinkFn sg
-        inType = intype $ head $ vertexList sg
-        outType= intype $ head $ reverse $ vertexList sg -- XXX not strictly true
+
+-- output type of a StreamGraph.
+-- special-case if the terminal node is a Sink node: we want the
+-- "pure" StreamGraph type that feeds into the sink function.
+outType :: StreamGraph -> String
+outType sg = let node = (head . reverse . vertexList) sg
+        in if operator node == Sink
+           then intype node
+           else outtype node
+
+-- input type of a StreamGraph
+-- see outType for rationale
+inType :: StreamGraph -> String
+inType sg = let node = (head  . vertexList) sg
+            in if operator node == Source
+               then outtype node
+               else intype node
+
+t = path [ StreamVertex 0 Source ["return 0"]       "IO Int" "Int"
+         , StreamVertex 1 Map    ["show","s"]       "Int" "String"
+         , StreamVertex 2 Sink   ["mapM_ putStrLn"] "String" "IO ()"
+         ]
+
+test_outType = assertEqual "String" $
+    (outType . head . fst) (createPartitions t [[0,1],[2]])
+
+test_outType_sink = assertEqual "String" $
+    (outType . head . fst) (createPartitions t [[0,1,2]])
+
+test_inType = assertEqual "Int" $
+    (inType . head . fst) (createPartitions t [[0,1],[2]])
 
 -- determine the node(s?) to connect on to from this partition
+-- XXX always 0 or 1? write quickcheck property...
 connectNodeId :: StreamGraph -> [(Integer, StreamGraph)] -> [StreamGraph] -> [Integer]
 connectNodeId sg parts cuts = let
     cut   = overlays cuts
@@ -219,13 +250,13 @@ partValence g cuts = let
 -- tests / test data
 
 -- Source -> Sink
-s0 = connect (Vertex (StreamVertex 0 (Source) [] "String"))
-    (Vertex (StreamVertex 1 (Sink) [] "String"))
+s0 = connect (Vertex (StreamVertex 0 (Source) [] "String" "String"))
+    (Vertex (StreamVertex 1 (Sink) [] "String" "String"))
 
 -- Source -> Filter -> Sink
-s1 = path [ StreamVertex 0 (Source) [] "String"
-          , StreamVertex 1 Filter [] "String"
-          , StreamVertex 2 (Sink) [] "String"
+s1 = path [ StreamVertex 0 (Source) [] "String" "String"
+          , StreamVertex 1 Filter [] "String" "String"
+          , StreamVertex 2 (Sink) [] "String" "String"
           ]
 
 test_reform_s0 = assertEqual s0 (unPartition $ createPartitions s0 [[0],[1]])
@@ -245,8 +276,9 @@ instance Arbitrary StreamVertex where
         operator <- arbitrary
         let parameters = []
             intype = "String"
+            outtype = "String"
             in
-                return $ StreamVertex vertexId operator parameters intype
+                return $ StreamVertex vertexId operator parameters intype outtype
 
 streamgraph :: Gen StreamGraph
 streamgraph = sized streamgraph'

--- a/src/VizGraph.hs
+++ b/src/VizGraph.hs
@@ -30,18 +30,18 @@ escape (x:xs) = if x == '"' then '\\':'"':(escape xs) else x:(escape xs)
 -- test data
 --source x = "do\n    threadDelay (1000*1000)\n    putStrLn \"sending '"++x++"'\"\n    return \""++x++"\""
 source x = "do threadDelay (1000*1000); putStrLn \"sending '"++x++"'\"; return \""++x++"\""
-v1 = StreamVertex 1 Source [source "foo"]  "String"
-v2 = StreamVertex 2 Map    ["Prelude.id"]  "String"
-v3 = StreamVertex 3 Source [source "bar"]  "String"
-v4 = StreamVertex 4 Map    ["Prelude.id"]  "String"
-v5 = StreamVertex 5 Merge  ["[n1,n2]"]     "String"
-v6 = StreamVertex 6 Sink   ["mapM_ print"] "String"
+v1 = StreamVertex 1 Source [source "foo"]  "String" "String"
+v2 = StreamVertex 2 Map    ["Prelude.id"]  "String" "String"
+v3 = StreamVertex 3 Source [source "bar"]  "String" "String"
+v4 = StreamVertex 4 Map    ["Prelude.id"]  "String" "String"
+v5 = StreamVertex 5 Merge  ["[n1,n2]"]     "[String]" "String"
+v6 = StreamVertex 6 Sink   ["mapM_ print"] "String" "IO ()"
 mergeEx :: StreamGraph
 mergeEx = overlay (path [v3, v4, v5]) (path [v1, v2, v5, v6])
 
-v7 = StreamVertex 1 Source ["<source of random tweets>"] "String"
-v8 = StreamVertex 2 Map    ["filter (('#'==).head) . words"] "[String]"
-v9 = StreamVertex 5 Expand [""]                 "[String]"
-v10 = StreamVertex 6 Sink   ["mapM_ print"] "String"
+v7 = StreamVertex 1 Source ["<source of random tweets>"] "String" "String"
+v8 = StreamVertex 2 Map    ["filter (('#'==).head) . words"] "String" "[String]"
+v9 = StreamVertex 5 Expand [""]                 "[String]" "String"
+v10 = StreamVertex 6 Sink   ["mapM_ print"] "String" "IO ()"
 expandEx :: StreamGraph
 expandEx = path [v7, v8, v9, v10]


### PR DESCRIPTION
After discussion with @PaulWatson9994 I've changed the approach in this PR, which was to try and fix inferring the output type of a StreamVertex/Graph, to explicitly defining an output type in the StreamVertex type.

Some mild work is still needed to look at the types of the penultimate or second nodes in the case of graphs with a source/sink, but it's much simpler, and I've provided some tests for assurance.

This is finally ready for review :-)

Fixes #36 .