### PR TITLE
Taxi as StreamGraph

### DIFF
--- a/examples/taxi/Makefile
+++ b/examples/taxi/Makefile
@@ -1,0 +1,26 @@
+run: nodes
+	docker-compose up --build
+
+nodes: node1/node1.hs node2/node2.hs node3/node3.hs node1/Taxi.hs node2/Taxi.hs node3/Taxi.hs
+
+node1/Taxi.hs: Taxi.hs
+	cp Taxi.hs node1
+
+node2/Taxi.hs: Taxi.hs
+	cp Taxi.hs node2
+
+node3/Taxi.hs: Taxi.hs
+	cp Taxi.hs node3
+
+node1/node1.hs node2/node2.hs node3/node3.hs: generate
+	./generate
+
+generate: generate.hs
+	ghc generate -i../../src
+
+clean:
+	rm -f generate generate.hi generate.o \
+            node1/node1.hs node2/node2.hs node3/node3.hs \
+	    node1/Taxi.hs node2/Taxi.hs node3/Taxi.hs
+
+.PHONY: clean nodes

--- a/examples/taxi/docker-compose.yml
+++ b/examples/taxi/docker-compose.yml
@@ -1,0 +1,13 @@
+node3:
+  build: node3
+  tty: true
+node2:
+  build: node2
+  links:
+    - node3
+  tty: true
+node1:
+  build: node1
+  links:
+    - node2
+  tty: true

--- a/examples/taxi/generate.hs
+++ b/examples/taxi/generate.hs
@@ -1,0 +1,49 @@
+{-
+    generate.hs for Taxi Q1
+-}
+
+import Striot.CompileIoT
+import Algebra.Graph
+import System.FilePath --(</>)
+
+import VizGraph
+
+imports = ["Striot.FunctionalIoTtypes", "Striot.FunctionalProcessing", "Striot.Nodes", "Taxi"
+    , "Data.Time" -- UTCTime(..)..
+    , "Data.Maybe" -- fromJust
+    , "Data.List.Split" -- splitOn
+    , "Control.Concurrent"] -- threadDelay
+
+source = "do\n\
+\   line <- getLine;\n\
+\   return $ stringsToTrip $ splitOn \",\" line"
+
+taxiQ1 :: StreamGraph
+taxiQ1 = path
+    [ StreamVertex 1 Source [source]                              "Trip"    "Trip"
+    , StreamVertex 2 Map    ["tripToJourney", "s"]                "Trip"    "Journey"
+    , StreamVertex 3 Filter ["(\\j -> inRangeQ1 (start j))", "s"] "Journey" "Journey"
+    , StreamVertex 4 Filter ["(\\j -> inRangeQ1 (end j))", "s"]   "Journey" "Journey"
+    , StreamVertex 5 Window ["(slidingJourneyTime 1800000)", "s"]        "Journey" "[Journey]"
+
+    , StreamVertex 6 Map    ["(\\w -> (let lj = last w in (pickupTime lj, dropoffTime lj), topk 10 w))", "s"] "[Journey]" "((UTCTime,UTCTime),[(Journey,Int)])"
+    -- journeyChanges
+    , StreamVertex 7 FilterAcc [ "(\\acc h -> if snd h == snd acc then acc else h)"
+                               , "(fromJust (value (head s)))"
+                               , "(\\h acc -> snd h /= snd acc)"
+                               , "(tail s)"
+                               ] "((UTCTime,UTCTime),[(Journey,Int)])" "((UTCTime,UTCTime),[(Journey,Int)])"
+    , StreamVertex 8 Sink   ["mapM_ (print.show.fromJust.value)"] "((UTCTime,UTCTime),[(Journey,Int)])" "IO ()"
+    ]
+
+parts = [[1..5],[6],[7..8]]
+partEx = generateCode taxiQ1 parts imports
+
+writePart :: (Char, String) -> IO ()
+writePart (x,y) = let
+    bn = "node" ++ (x:[])
+    fn = bn </> bn ++ ".hs"
+    in
+        writeFile fn y
+
+main = mapM_ writePart (zip ['1'..] partEx)

--- a/examples/taxi/node1/Dockerfile
+++ b/examples/taxi/node1/Dockerfile
@@ -1,0 +1,5 @@
+FROM striot/striot-base:latest
+WORKDIR /opt/client
+COPY . /opt/client
+RUN ghc node1.hs
+CMD ["/bin/sh", "-c", "/opt/client/node1 < /opt/client/sorteddata.csv"]

--- a/examples/taxi/node2/Dockerfile
+++ b/examples/taxi/node2/Dockerfile
@@ -1,0 +1,6 @@
+FROM striot/striot-base:latest
+WORKDIR /opt/server
+COPY . /opt/server
+RUN ghc node2.hs
+EXPOSE 9001
+CMD /opt/server/node2

--- a/examples/taxi/node3/Dockerfile
+++ b/examples/taxi/node3/Dockerfile
@@ -1,0 +1,6 @@
+FROM striot/striot-base:latest
+WORKDIR /opt/server
+COPY . /opt/server
+RUN ghc node3.hs
+EXPOSE 9001
+CMD /opt/server/node3


### PR DESCRIPTION
I'm raising this before it's ready (WIP state) just to help me organise my TODO list for getting it merge-ready, but also because I might need some help!

This adds an alternative implementation of the Taxi stream graphs, as StreamGraph data structures, in the same vein as most of the other examples.

Apart from some clean-up in this branch (bits need pulling out and raising in separate PRs, and the result rebase and some squashing applying), the problem I've hit is: the sink node is not receiving any data.

I've tried ruling out docker and docker-compose, running the node1 and node2 binaries on the same machine (talking to localhost), and inserting an instance of `netcat` in between them.

By altering node1 to print out each stream item before its sent, I can see it gradually consume the input CSV.

By injecting netcat between the nodes (`netcat -l 9001 | tee /dev/stderr | netcat localhost 9002`), node1 connecting to 9001 and node2 listening on 9002, I can see the data in transit (encoded as JSON), but node2 still prints nothing

I tried the same technique with another example (simplest) and I saw the data in all three places (client, netcat, server). So the issue appears to be in the sink end of this example (node2). I have a hunch it could be related to de-serialization.