### PR TITLE
Modify sliding time to remove internal where statements

### DIFF
--- a/src/Striot/FunctionalProcessing.hs
+++ b/src/Striot/FunctionalProcessing.hs
@@ -79,11 +79,12 @@ sliding wLength s = sliding' wLength $ filter dataEvent s
                  sliding' wLength s@(h:t) = (take wLength s) : sliding' wLength t
 
 slidingTime:: Int -> WindowMaker alpha  -- the first argument is the window length in milliseconds
-slidingTime _       []                        = []
-slidingTime tLength s@(Event _ (Just t) _:xs) =
-    let (fstBuffer,_) = timeTake (addUTCTime (milliToTimeDiff tLength) t)
-                      $ filter timedEvent s
-    in  fstBuffer : slidingTime tLength xs
+slidingTime _       []                         = []
+slidingTime tLength s = slidingTime' (milliToTimeDiff tLength) $ filter timedEvent s
+    where slidingTime' _    []                        = []
+          slidingTime' tLen s@(Event _ (Just t) _:xs) =
+              let (fstBuffer,_) = timeTake (addUTCTime tLen t) s
+              in  fstBuffer : slidingTime' tLen xs
 
 timeTake :: UTCTime -> Stream alpha -> (Stream alpha, Stream alpha)
 timeTake endTime s = span (\(Event _ (Just t) _) -> t < endTime) s -- changed from <=

--- a/src/Striot/FunctionalProcessing.hs
+++ b/src/Striot/FunctionalProcessing.hs
@@ -79,11 +79,11 @@ sliding wLength s = sliding' wLength $ filter dataEvent s
                  sliding' wLength s@(h:t) = (take wLength s) : sliding' wLength t
 
 slidingTime:: Int -> WindowMaker alpha  -- the first argument is the window length in milliseconds
-slidingTime _       []                         = []
-slidingTime tLength s@((Event _ (Just t) _):_) = slidingTime' tLength t $ filter timedEvent s
-    where slidingTime':: Int -> UTCTime -> WindowMaker alpha
-          slidingTime' tLength tStart s@(h:t) = fstBuffer : slidingTime tLength t
-                 where fstBuffer = fst $ timeTake (addUTCTime (milliToTimeDiff tLength) tStart) s
+slidingTime _       []                        = []
+slidingTime tLength s@(Event _ (Just t) _:xs) =
+    let (fstBuffer,_) = timeTake (addUTCTime (milliToTimeDiff tLength) t)
+                      $ filter timedEvent s
+    in  fstBuffer : slidingTime tLength xs
 
 timeTake :: UTCTime -> Stream alpha -> (Stream alpha, Stream alpha)
 timeTake endTime s = span (\(Event _ (Just t) _) -> t < endTime) s -- changed from <=


### PR DESCRIPTION
I think that the definition of `slidingTime` is either not evaluating lazily, or retaining unneeded references due to the where statements.

Using the Taxi example and the following function (an explicit re-write of query2, removing the `streamJoinW`) you can easily tell the difference of comparing the old `slidingTime` vs the new. With the new, the memory usage stops at around 170M, vs the old version where it rises quickly. The new one also appears to perform much faster for this kind of operation.
```
q2Test :: IO ()
q2Test = do
    contents <- readFile "sorteddata.csv"
    let s               = tripSource contents
        processedStream = streamFilter (\(_, j) -> inRangeQ2 (start j) && inRangeQ2 (end j))
                        $ streamMap (\t -> (t, tripToJourney t)) s
        cp              = streamMap cellProfit
                        $ streamWindow (slidingTime 900000) processedStream
        etpc            = streamMap emptyTaxisPerCell
                        $ streamWindow (slidingTime 1800000) processedStream
    mapM_ print $ streamMap length
                $ streamWindow (slidingTime 1800000)
                $ streamMap (uncurry profitability)
                $ streamJoin etpc cp
```