### PR TITLE
don't use Show instance for VizGraph

### DIFF
--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -9,7 +9,7 @@ module Striot.CompileIoT ( StreamGraph(..)
                          , htf_thisModulesTests
                          ) where
 
-import Data.List (intersperse, intercalate)
+import Data.List (intercalate)
 import Algebra.Graph
 import Test.Framework
 
@@ -44,13 +44,10 @@ data StreamVertex = StreamVertex
     , parameters :: [String] -- XXX strings of code. From CompileIoT. Variable length e.g.FilterAcc takes 3 (?)
     , intype     :: String
     , outtype    :: String
-    } deriving (Eq)
+    } deriving (Eq,Show)
 
 instance Ord StreamVertex where
     compare (StreamVertex x _ _ _ _) (StreamVertex y _ _ _ _) = compare x y
-
-instance Show StreamVertex where
-    show v = intercalate " " $ ((show . operator) v) : ((map (\s->"("++s++")")) . parameters) v
 
 ------------------------------------------------------------------------------
 -- StreamGraph Partitioning

--- a/src/VizGraph.hs
+++ b/src/VizGraph.hs
@@ -7,9 +7,13 @@ import Algebra.Graph
 import Algebra.Graph.Export.Dot
 import Data.String
 import Test.Framework
+import Data.List (intercalate)
 
 streamGraphToDot :: StreamGraph -> String
 streamGraphToDot = export myStyle
+
+show' :: StreamVertex -> String
+show' v = intercalate " " $ ((show . operator) v) : ((map (\s->"("++s++")")) . parameters) v
 
 myStyle :: Style StreamVertex String
 myStyle = Style
@@ -19,7 +23,7 @@ myStyle = Style
     , defaultVertexAttributes = ["shape" := "box","fillcolor":="white","style":="filled"]
     , defaultEdgeAttributes   = ["weight":="10","color":="black","fontcolor":="black"]
     , vertexName              = show . vertexId
-    , vertexAttributes        = (\v -> ["label":=(escape . show) v])
+    , vertexAttributes        = (\v -> ["label":=(escape . show') v])
     , edgeAttributes          = (\_ o -> ["label":=intype o])
     }
 


### PR DESCRIPTION
Derive Show instances for StreamGraph and StreamOperator
instead of directly implementing instances for the purposes
of VizGraph.

This makes debugging issues in GHCi easier, since the derived Show
implementation resembles the source code for the constructors.

Move the older "show" implementation to a private function in
VizGraph.hs.