### PR TITLE
add Stack stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-13.10
+packages:
+- .
+extra-deps:
+- unagi-chan-0.4.1.0


### PR DESCRIPTION
This is a configuration file for Stack (generated with "stack init" and only
tested with version 1.1.2).

I keep hitting problems trying to maintain a global package collection (via
cabal) that works for the projects I have open and frequently break it,
preventing me from testing something in Striot. Using Stack, I believe I can
maintain an isolated collection of libraries (and GHC) and so avoid this
problem.

I have *not* tested this yet with a more modern Stack version but I shall
(I have had problems with the format of stack.yaml files generated by newer
Stack versions not working with 1.1.2… but hopefully it's better at backwards
compatibility than forwards)