### PR TITLE
Prometheus metrics

### DIFF
--- a/striot.cabal
+++ b/striot.cabal
@@ -36,6 +36,8 @@ library
                     , store
                     , store-streaming
                     , async
+                    , prometheus
+                    , text
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -57,6 +59,8 @@ test-suite test-striot
                     , store
                     , store-streaming
                     , async
+                    , prometheus
+                    , text
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing

--- a/striot.cabal
+++ b/striot.cabal
@@ -23,7 +23,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:      base              >= 4.9
-                    , network           >= 2.6.0.0
+                    , network           >= 3.0.0.0
                     , containers        >= 0.5
                     , split             >= 0.2
                     , time              >= 1.6
@@ -46,7 +46,7 @@ test-suite test-striot
   type:               exitcode-stdio-1.0
   Main-is:            TestMain.hs
   build-depends:      base              >= 4.9
-                    , network           >= 2.6.0.0
+                    , network           >= 3.0.0.0
                     , containers        >= 0.5
                     , split             >= 0.2
                     , time              >= 1.6


### PR DESCRIPTION
An initial implementation of prometheus metrics. Built on top of PR #61, so should not be merged until we know the outcome of this.

Currently this allows us to track the following for both ingress/egress:

- Current number of connections
- Total number of bytes
- Total number of Events

The metrics endpoint is set to the default, http://localhost:8080/metrics. To use with `docker-compose` within the examples, the [ports](https://docs.docker.com/compose/compose-file/#ports) must be mapped from the container to host.

Testing required to find how this might affect performance.

Resolves: #59 