### PR TITLE
introduce simpleStream for Taxi example

### DIFF
--- a/examples/taxi/Makefile
+++ b/examples/taxi/Makefile
@@ -1,6 +1,9 @@
 run: nodes
 	docker-compose up --build
 
+gen: generate
+	./generate
+
 nodes: node1/node.hs node2/node.hs node3/node.hs node1/Taxi.hs node2/Taxi.hs node3/Taxi.hs
 
 node1/Taxi.hs: Taxi.hs
@@ -24,6 +27,7 @@ clean:
 	    node1/node.hs node2/node.hs node3/node.hs \
 	    node1/Taxi.hs node2/Taxi.hs node3/Taxi.hs \
 	    node1/Dockerfile node2/Dockerfile node3/Dockerfile
-	-rmdir node2 node3
+	-test ! -d node2 || rmdir node2
+	-test ! -d node3 || rmdir node3
 
-.PHONY: clean nodes
+.PHONY: clean nodes gen

--- a/examples/taxi/generate.hs
+++ b/examples/taxi/generate.hs
@@ -8,14 +8,14 @@ import Algebra.Graph
 import VizGraph
 
 opts = GenerateOpts { imports = [ "Striot.FunctionalIoTtypes"
-                                   , "Striot.FunctionalProcessing"
-                                   , "Striot.Nodes"
-                                   , "Taxi"
-                                   , "Data.Time" -- UTCTime(..)..
-                                   , "Data.Maybe" -- fromJust
-                                   , "Data.List.Split" -- splitOn
-                                   , "Control.Concurrent"
-                                   ] -- threadDelay
+                                , "Striot.FunctionalProcessing"
+                                , "Striot.Nodes"
+                                , "Taxi"
+                                , "Data.Time" -- UTCTime(..)..
+                                , "Data.Maybe" -- fromJust
+                                , "Data.List.Split" -- splitOn
+                                , "Control.Concurrent"
+                                ] -- threadDelay
                     , packages = []
                     , preSource = Just "preSource"
                     }
@@ -23,27 +23,25 @@ source = "do\n\
 \   line <- getLine;\n\
 \   return $ stringsToTrip $ splitOn \",\" line"
 
-taxiQ1 :: StreamGraph
-taxiQ1 = path
-    [ StreamVertex 1 Source [source]                              "Trip"    "Trip"
-
-    -- set Event timestamps to Trip dropoffDateTime
-    , StreamVertex 2 Window ["tripTimes","s"] "Trip" "[Trip]"
-    , StreamVertex 3 Expand ["s"] "[Trip]" "Trip"
-
-    , StreamVertex 4 Map    ["tripToJourney", "s"]                "Trip"    "Journey"
-    , StreamVertex 5 Filter ["(\\j -> inRangeQ1 (start j))", "s"] "Journey" "Journey"
-    , StreamVertex 6 Filter ["(\\j -> inRangeQ1 (end j))", "s"]   "Journey" "Journey"
-    , StreamVertex 7 Window ["(slidingTime 1800000)", "s"]        "Journey" "[Journey]"
-
-    , StreamVertex 8 Map    ["(\\w -> (let lj = last w in (pickupTime lj, dropoffTime lj), topk 10 w))", "s"] "[Journey]" "((UTCTime,UTCTime),[(Journey,Int)])"
-    -- journeyChanges
-    , StreamVertex 9 FilterAcc [ "(\\acc h -> if snd h == snd acc then acc else h)"
+topk = "(\\w -> (let lj = last w in (pickupTime lj, dropoffTime lj), topk 10 w))"
+filterDupes = ["(\\acc h -> if snd h == snd acc then acc else h)"
                                , "(fromJust (value (head s)))"
                                , "(\\h acc -> snd h /= snd acc)"
-                               , "(tail s)"
-                               ] "((UTCTime,UTCTime),[(Journey,Int)])" "((UTCTime,UTCTime),[(Journey,Int)])"
-    , StreamVertex 10 Sink   ["mapM_ (print.show.fromJust.value)"] "((UTCTime,UTCTime),[(Journey,Int)])" "IO ()"
+                               , "(tail s)"  ]
+sink = "mapM_ (print.show.fromJust.value)"
+
+taxiQ1 :: StreamGraph
+taxiQ1 = simpleStream
+    [ (Source,    [source],                             "Trip")
+    , (Window,    ["tripTimes","s"],                    "[Trip]")
+    , (Expand,    ["s"],                                "Trip")
+    , (Map,       ["tripToJourney", "s"],               "Journey")
+    , (Filter,    ["(\\j -> inRangeQ1 (start j))", "s"],"Journey")
+    , (Filter,    ["(\\j -> inRangeQ1 (end j))", "s"],  "Journey")
+    , (Window,    ["(slidingTime 1800000)", "s"],       "[Journey]")
+    , (Map,       [topk, "s"],                          "((UTCTime,UTCTime),[(Journey,Int)])")
+    , (FilterAcc, filterDupes,                          "((UTCTime,UTCTime),[(Journey,Int)])")
+    , (Sink,      [sink],                               "((UTCTime,UTCTime),[(Journey,Int)])")
     ]
 
 parts = [[1..7],[8],[9..10]]

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -11,6 +11,7 @@ module Striot.CompileIoT ( StreamGraph(..)
                          , writePart
                          , genDockerfile
                          , partitionGraph
+                         , simpleStream
 
                          , htf_thisModulesTests
                          ) where
@@ -335,3 +336,12 @@ writePart opts (x,y) = let
 partitionGraph :: StreamGraph -> PartitionMap -> GenerateOpts -> IO ()
 partitionGraph graph partitions opts =
     mapM_ (writePart opts) $ zip [1..] $ generateCode graph partitions opts
+
+simpleStream :: [(StreamOperator, [String], String)] -> Graph StreamVertex
+simpleStream tupes = path lst
+
+    where
+        intypes = "IO ()" : (map (\(_,_,ty) -> ty) (init tupes))
+        tupes3 = zip3 [1..] intypes tupes
+        lst = map (\ (i,intype,(op,params,outtype)) ->
+            StreamVertex i op params intype outtype) tupes3


### PR DESCRIPTION
simpleStream, a convenience function for defining a StreamGraph in the
simple case of a linear list of operators (no merges or joins)

We can elide the vertex ID and input types in this specific case

I did this originally in order to simplify the presentation of the Taxi
generate.hs for a live demo.