### PR TITLE
add displayGraph to VizGraph

### DIFF
--- a/src/VizGraph.hs
+++ b/src/VizGraph.hs
@@ -1,6 +1,8 @@
 {-# OPTIONS_GHC -F -pgmF htfpp #-}
 
-module VizGraph(streamGraphToDot, htf_thisModulesTests) where
+module VizGraph ( streamGraphToDot
+                , displayGraph
+                , htf_thisModulesTests) where
 
 import Striot.CompileIoT
 import Algebra.Graph
@@ -8,6 +10,9 @@ import Algebra.Graph.Export.Dot
 import Data.String
 import Test.Framework
 import Data.List (intercalate)
+
+import System.Process
+import System.IO (openTempFile, hPutStr, hClose)
 
 streamGraphToDot :: StreamGraph -> String
 streamGraphToDot = export myStyle
@@ -49,3 +54,11 @@ v9 = StreamVertex 5 Expand [""]                 "[String]" "String"
 v10 = StreamVertex 6 Sink   ["mapM_ print"] "String" "IO ()"
 expandEx :: StreamGraph
 expandEx = path [v7, v8, v9, v10]
+
+displayGraph :: StreamGraph -> IO ()
+displayGraph g = do
+    (srcPath, srcHandle) <- openTempFile "/tmp" "graph.dot"
+    hPutStr srcHandle (streamGraphToDot g)
+    hClose srcHandle
+    rawSystem "/bin/sh" ["-c", "dot -Tpng "++srcPath++"| display - &"]
+    return ()

--- a/src/VizGraph.hs
+++ b/src/VizGraph.hs
@@ -57,8 +57,9 @@ expandEx = path [v7, v8, v9, v10]
 
 displayGraph :: StreamGraph -> IO ()
 displayGraph g = do
-    (srcPath, srcHandle) <- openTempFile "/tmp" "graph.dot"
-    hPutStr srcHandle (streamGraphToDot g)
-    hClose srcHandle
-    rawSystem "/bin/sh" ["-c", "dot -Tpng "++srcPath++"| display - &"]
-    return ()
+    (Just hin,Just hout,_, _) <- createProcess (proc "dot" ["-Tpng"])
+      { std_out = CreatePipe, std_in = CreatePipe }
+    _ <- createProcess (proc "display" []){ std_in = UseHandle hout }
+
+    hPutStr hin (streamGraphToDot g)
+    hClose hin


### PR DESCRIPTION
displayGraph takes a StreamGraph and converts it to dot source,
spawns a "dot" process, spawns a "display" process, connects
them together with pipes and pushes the dot source into the
pipeline.

this is useful for rapidly displaying a visual representation
of a StreamGraph whilst experimenting in GHCi, assuming your
system has "dot" and "display" installed, and assuming they
are in your $PATH (or %PATH%)

I *think* this will work on Windows; but I have only tested
it on Linux.