### PR TITLE
Enable continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: haskell
+
+ghc:
+  - "8.4.3"
+
+services:
+  - docker
+
+stages:
+  - install
+  - build
+  - name: image
+    if: branch = master AND type = push
+
+install:
+  - cabal install happy
+  - cabal install --only-dependencies --enable-tests
+
+jobs:
+  include:
+    - stage: build
+      name: Build and test striot
+    - stage: image
+      install: true
+      name: Build striot-base docker image 
+      script:
+        - make -C containers/
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - docker push striot/striot-base:latest
+


### PR DESCRIPTION
This PR enables Travis CI. It will build and test the Striot library using the following commands:

```
cabal install happy
cabal install --only-dependencies --enable-tests
```

```
cabal configure --enable-tests && cabal build && cabal test
```

As Travis is using a containerised environment for the builds we have to manually install `happy` in the same way as we do for our own docker builds, hopefully we can remove this once the containers are fixed.

On merging a PR to `master` it should automatically build the `striot/striot-base:latest` image and push it to the docker hub repository.

Closes #64 