### PR TITLE
Update image building for GHC 8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: haskell
 
 ghc:
-  - "8.4.3"
+  - "8.6"
 
 services:
   - docker
@@ -22,9 +22,8 @@ jobs:
       name: Build and test striot
     - stage: image
       install: true
-      name: Build striot-base docker image 
+      name: Build striot-base docker image
       script:
         - make -C containers/
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - docker push striot/striot-base:latest
-

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -2,6 +2,7 @@ prefix = striot
 
 base = striot-base/striot
 license = $(base)/LICENSE
+readme = $(base)/README.md
 cabal = $(base)/striot.cabal
 
 src_dir := $(base)/src
@@ -9,7 +10,7 @@ in_srcs := $(wildcard ../src/*.hs) $(wildcard ../src/**/*.hs)
 out_srcs := $(subst ..,$(base),$(in_srcs))
 
 .PHONY: all
-all: $(cabal) $(license) $(out_srcs)
+all: $(cabal) $(license) $(readme) $(out_srcs)
 	@echo "Building image $(prefix)/striot-base"
 	@docker build -t $(prefix)/striot-base striot-base
 
@@ -21,6 +22,9 @@ $(cabal): $(src_dir) ../striot.cabal
 
 $(license): $(src_dir) ../LICENSE
 	@cp -R ../LICENSE $(base)/
+
+$(readme): $(src_dir) ../README.md
+	@cp -R ../README.md $(base)/
 
 $(src_dir):
 	@mkdir -p $(src_dir)

--- a/containers/striot-base/Dockerfile
+++ b/containers/striot-base/Dockerfile
@@ -1,5 +1,5 @@
 # Run from a pre-built Haskell container
-FROM haskell:8.4
+FROM haskell:8.6
 
 RUN apt-get update && apt-get upgrade -y
 
@@ -10,13 +10,13 @@ WORKDIR /opt/striot
 
 # Install all dependencies defined in cabal file - we must install happy
 # separately for HTF, as the image has a bootstrapping problem
-RUN cabal update && \
-    cabal install happy && \
-    cabal install --only-dependencies
+RUN cabal v1-update && \
+    cabal v1-install happy && \
+    cabal v1-install --only-dependencies
 
 # Copy over source code in a separate layer, ensuring above is cached if
 # cabal file does not change
 COPY striot/src /opt/striot/src
 
-RUN cabal build && \
-    cabal install
+RUN cabal v1-build && \
+    cabal v1-install

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,8 @@
-resolver: lts-13.10
+resolver: lts-13.25
 packages:
 - .
 extra-deps:
+- network-3.1.0.0
+- prometheus-2.1.2
+- store-streaming-0.1.0.0
 - unagi-chan-0.4.1.0

--- a/striot.cabal
+++ b/striot.cabal
@@ -36,7 +36,7 @@ library
                     , store
                     , store-streaming
                     , async
-                    , prometheus
+                    , prometheus        >= 2.0.0
                     , text
   hs-source-dirs:     src
   default-language:   Haskell2010
@@ -44,7 +44,7 @@ library
 test-suite test-striot
   hs-source-dirs:     src
   type:               exitcode-stdio-1.0
-  Main-is:            TestMain.hs
+  main-is:            TestMain.hs
   build-depends:      base              >= 4.9
                     , network           >= 3.0.0.0
                     , containers        >= 0.5
@@ -59,11 +59,11 @@ test-suite test-striot
                     , store
                     , store-streaming
                     , async
-                    , prometheus
+                    , prometheus        >= 2.0.0
                     , text
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing
                       Striot.Nodes
                       VizGraph
-  Default-language:   Haskell2010
+  default-language:   Haskell2010


### PR DESCRIPTION
We currently have our `stack.yaml` set using GHC `8.6` but the docker container is building GHC `8.4`.

- Added the README to the docker image.
- Updated prometheus minimum version.

We night need to consider what is required regarding moving to `cabal new-style` projects, so for the time being I have set it to `v1` commands (so that it does not break on the next `cabal-install` release).