### PR TITLE
Add missing dependency 'process' package

### DIFF
--- a/striot.cabal
+++ b/striot.cabal
@@ -38,6 +38,7 @@ library
                     , async
                     , prometheus        >= 2.0.0
                     , text
+                    , process
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -61,6 +62,7 @@ test-suite test-striot
                     , async
                     , prometheus        >= 2.0.0
                     , text
+                    , process
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing


### PR DESCRIPTION
CI didn't catch this as I set it up after PR #67 was opened, but caught it on merge of PR #69. It should catch this sort of thing in future :)