### PR TITLE
WIP: Add new connection types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,15 @@ stages:
   - name: image
     if: branch = master AND type = push
 
+before_install:
+  - wget -qO - https://packages.confluent.io/deb/5.3/archive.key | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/5.3 stable main"
+  - sudo apt-get update && sudo apt-get install librdkafka-dev
+
 install:
-  - cabal install happy
-  - cabal install --only-dependencies --enable-tests
+  - cabal install happy alex
+  - cabal install c2hs
+  - cabal install --only-dependencies --enable-tests --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
 
 jobs:
   include:

--- a/containers/striot-base/Dockerfile
+++ b/containers/striot-base/Dockerfile
@@ -3,6 +3,15 @@ FROM haskell:8.6
 
 RUN apt-get update && apt-get upgrade -y
 
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+
+# Install the librdkafka library for Kafka
+RUN git clone https://github.com/edenhill/librdkafka && \
+    cd librdkafka && \
+    git checkout $(git describe --tags `git rev-list --tags --max-count=1`) && \
+    ./configure --install-deps && \
+    make && make install
+
 # Copy cabal file and license
 COPY striot/striot.cabal striot/LICENSE /opt/striot/
 
@@ -11,8 +20,9 @@ WORKDIR /opt/striot
 # Install all dependencies defined in cabal file - we must install happy
 # separately for HTF, as the image has a bootstrapping problem
 RUN cabal v1-update && \
-    cabal v1-install happy && \
-    cabal v1-install --only-dependencies
+    cabal v1-install happy alex && \
+    cabal v1-install c2hs && \
+    cabal v1-install --only-dependencies --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
 
 # Copy over source code in a separate layer, ensuring above is cached if
 # cabal file does not change

--- a/examples/pipeline-kafka/docker-compose.yml
+++ b/examples/pipeline-kafka/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3"
+services:
+  kafka:
+    image: wurstmeister/kafka:latest
+    ports:
+      - "9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_CREATE_TOPICS: "striot-queue:1:1"
+  zookeeper:
+      image: wurstmeister/zookeeper:latest
+      ports:
+        - "2181"
+  node3:
+    build: node3
+    ports:
+      - "9001"
+    stdin_open: true
+    tty: true
+  node2:
+    build: node2
+    ports:
+      - "9001"
+    stdin_open: true
+    tty: true
+    depends_on:
+      - kafka
+      - node3
+  node1:
+    build: node1
+    stdin_open: true
+    tty: true
+    depends_on:
+      - kafka
+      - node2

--- a/examples/pipeline-kafka/node1/Dockerfile
+++ b/examples/pipeline-kafka/node1/Dockerfile
@@ -1,0 +1,6 @@
+FROM striot/striot-base:latest
+WORKDIR /opt/node
+COPY . /opt/node
+
+RUN ghc node.hs
+CMD /opt/node/node

--- a/examples/pipeline-kafka/node1/node.hs
+++ b/examples/pipeline-kafka/node1/node.hs
@@ -1,0 +1,20 @@
+-- node1
+import Striot.FunctionalIoTtypes
+import Striot.FunctionalProcessing
+import Striot.Nodes
+import Control.Concurrent
+
+
+src1 = do
+    threadDelay (1000*1000)
+    return "Hello from Client!"
+
+streamGraphFn :: Stream String -> Stream String
+streamGraphFn n1 = let
+    n2 = (\s -> streamMap (\st->st++st) s) n1
+    in n2
+
+
+main :: IO ()
+main = do
+       nodeSourceKafka src1 streamGraphFn "node1" "kafka" "9092"

--- a/examples/pipeline-kafka/node2/Dockerfile
+++ b/examples/pipeline-kafka/node2/Dockerfile
@@ -1,0 +1,6 @@
+FROM striot/striot-base:latest
+WORKDIR /opt/node
+COPY . /opt/node
+
+RUN ghc node.hs
+CMD /opt/node/node

--- a/examples/pipeline-kafka/node2/node.hs
+++ b/examples/pipeline-kafka/node2/node.hs
@@ -1,0 +1,15 @@
+-- node2
+import Striot.FunctionalIoTtypes
+import Striot.FunctionalProcessing
+import Striot.Nodes
+import Control.Concurrent
+
+
+streamGraphFn :: Stream String -> Stream String
+streamGraphFn n1 = let
+    n2 = (\s -> streamMap reverse s) n1
+    in n2
+
+
+main :: IO ()
+main = nodeLinkKafka streamGraphFn "node2" "kafka" "9092" "node3" "9001"

--- a/examples/pipeline-kafka/node3/Dockerfile
+++ b/examples/pipeline-kafka/node3/Dockerfile
@@ -1,0 +1,7 @@
+FROM striot/striot-base:latest
+WORKDIR /opt/node
+COPY . /opt/node
+
+RUN ghc node.hs
+EXPOSE 9001
+CMD /opt/node/node

--- a/examples/pipeline-kafka/node3/node.hs
+++ b/examples/pipeline-kafka/node3/node.hs
@@ -1,0 +1,20 @@
+-- node3
+import Striot.FunctionalIoTtypes
+import Striot.FunctionalProcessing
+import Striot.Nodes
+import Control.Concurrent
+
+
+sink1 :: Show a => Stream a -> IO ()
+sink1 = mapM_ print
+
+
+streamGraphFn :: Stream String -> Stream [String]
+streamGraphFn n1 = let
+    n2 = (\s -> streamMap (\st->"Incoming Message at Server: " ++ st) s) n1
+    n3 = (\s -> streamWindow (chop 2) s) n2
+    in n3
+
+
+main :: IO ()
+main = nodeSink streamGraphFn sink1 "9001"

--- a/examples/pipeline-mqtt/docker-compose.yml
+++ b/examples/pipeline-mqtt/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3"
+services:
+  mqtt:
+    image: eclipse-mosquitto:latest
+    ports:
+      - "1883"
+  node3:
+    build: node3
+    stdin_open: true
+    tty: true
+    ports:
+      - "9001"
+  node2:
+    build: node2
+    ports:
+      - "9001"
+    stdin_open: true
+    tty: true
+    depends_on:
+      - mqtt
+      - node3
+  node1:
+    build: node1
+    depends_on:
+      - mqtt
+      - node2

--- a/examples/pipeline-mqtt/node1/Dockerfile
+++ b/examples/pipeline-mqtt/node1/Dockerfile
@@ -1,0 +1,6 @@
+FROM striot/striot-base:latest
+WORKDIR /opt/node
+COPY . /opt/node
+
+RUN ghc node.hs
+CMD /opt/node/node

--- a/examples/pipeline-mqtt/node1/node.hs
+++ b/examples/pipeline-mqtt/node1/node.hs
@@ -1,0 +1,20 @@
+-- node1
+import Striot.FunctionalIoTtypes
+import Striot.FunctionalProcessing
+import Striot.Nodes
+import Control.Concurrent
+
+
+src1 = do
+    threadDelay (1000*1000)
+    return "Hello from Client!"
+
+streamGraphFn :: Stream String -> Stream String
+streamGraphFn n1 = let
+    n2 = (\s -> streamMap (\st->st++st) s) n1
+    in n2
+
+
+main :: IO ()
+main = do
+       nodeSourceMqtt src1 streamGraphFn "node1" "mqtt" "1883"

--- a/examples/pipeline-mqtt/node2/Dockerfile
+++ b/examples/pipeline-mqtt/node2/Dockerfile
@@ -1,0 +1,6 @@
+FROM striot/striot-base:latest
+WORKDIR /opt/node
+COPY . /opt/node
+
+RUN ghc node.hs
+CMD /opt/node/node

--- a/examples/pipeline-mqtt/node2/node.hs
+++ b/examples/pipeline-mqtt/node2/node.hs
@@ -1,0 +1,15 @@
+-- node2
+import Striot.FunctionalIoTtypes
+import Striot.FunctionalProcessing
+import Striot.Nodes
+import Control.Concurrent
+
+
+streamGraphFn :: Stream String -> Stream String
+streamGraphFn n1 = let
+    n2 = (\s -> streamMap reverse s) n1
+    in n2
+
+
+main :: IO ()
+main = nodeLinkMqtt streamGraphFn "node2" "mqtt" "1883" "node3" "9001"

--- a/examples/pipeline-mqtt/node3/Dockerfile
+++ b/examples/pipeline-mqtt/node3/Dockerfile
@@ -1,0 +1,7 @@
+FROM striot/striot-base:latest
+WORKDIR /opt/node
+COPY . /opt/node
+
+RUN ghc node.hs
+EXPOSE 9001
+CMD /opt/node/node

--- a/examples/pipeline-mqtt/node3/node.hs
+++ b/examples/pipeline-mqtt/node3/node.hs
@@ -1,0 +1,20 @@
+-- node3
+import Striot.FunctionalIoTtypes
+import Striot.FunctionalProcessing
+import Striot.Nodes
+import Control.Concurrent
+
+
+sink1 :: Show a => Stream a -> IO ()
+sink1 = mapM_ print
+
+
+streamGraphFn :: Stream String -> Stream [String]
+streamGraphFn n1 = let
+    n2 = (\s -> streamMap (\st->"Incoming Message at Server: " ++ st) s) n1
+    n3 = (\s -> streamWindow (chop 2) s) n2
+    in n3
+
+
+main :: IO ()
+main = nodeSink streamGraphFn sink1 "9001"

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,3 +10,4 @@ extra-deps:
 - websockets-0.12.6.1
 - connection-0.3.1
 - socks-0.6.1
+- hw-kafka-client-3.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ extra-deps:
 - prometheus-2.1.2
 - store-streaming-0.1.0.0
 - unagi-chan-0.4.1.0
-- net-mqtt-0.6.2.0
+- net-mqtt-0.6.2.1
 - websockets-0.12.6.1
 - connection-0.3.1
 - socks-0.6.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,3 +6,7 @@ extra-deps:
 - prometheus-2.1.2
 - store-streaming-0.1.0.0
 - unagi-chan-0.4.1.0
+- net-mqtt-0.6.2.0
+- websockets-0.12.6.1
+- connection-0.3.1
+- socks-0.6.1

--- a/striot.cabal
+++ b/striot.cabal
@@ -43,6 +43,7 @@ library
                     , stm
                     , deepseq
                     , network-uri
+                    , hw-kafka-client   >= 2.6.0
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -71,6 +72,7 @@ test-suite test-striot
                     , stm
                     , deepseq
                     , network-uri
+                    , hw-kafka-client   >= 2.6.0
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing

--- a/striot.cabal
+++ b/striot.cabal
@@ -37,13 +37,13 @@ library
                     , store-streaming
                     , async
                     , prometheus        >= 2.0.0
-                    , net-mqtt          >= 0.6.2.0
+                    , net-mqtt          >= 0.6.2.1
                     , text
                     , process
                     , stm
                     , deepseq
                     , network-uri
-                    , hw-kafka-client   >= 2.6.0
+                    , hw-kafka-client   >= 3.0.0
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -66,13 +66,13 @@ test-suite test-striot
                     , store-streaming
                     , async
                     , prometheus        >= 2.0.0
-                    , net-mqtt          >= 0.6.2.0
+                    , net-mqtt          >= 0.6.2.1
                     , text
                     , process
                     , stm
                     , deepseq
                     , network-uri
-                    , hw-kafka-client   >= 2.6.0
+                    , hw-kafka-client   >= 3.0.0
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing

--- a/striot.cabal
+++ b/striot.cabal
@@ -37,8 +37,12 @@ library
                     , store-streaming
                     , async
                     , prometheus        >= 2.0.0
+                    , net-mqtt          >= 0.6.2.0
                     , text
                     , process
+                    , stm
+                    , deepseq
+                    , network-uri
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -61,8 +65,12 @@ test-suite test-striot
                     , store-streaming
                     , async
                     , prometheus        >= 2.0.0
+                    , net-mqtt          >= 0.6.2.0
                     , text
                     , process
+                    , stm
+                    , deepseq
+                    , network-uri
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing


### PR DESCRIPTION
This pull request will contain changes to allow us to have different connection types between nodes.

I am trying to sort through and cleanup code for connecting to both `MQTT` and `Kafka`. For each I am adding a new example using the broker in question. These examples do not follow the old format as the `node` functions change, and so it won't be as straightforward to use the generator. So far this is just the code for the `MQTT` side of things.