### PR TITLE
Implement more filter rules

### DIFF
--- a/examples/taxi/Makefile
+++ b/examples/taxi/Makefile
@@ -25,6 +25,8 @@ clean:
 	rm -f generate generate.hi generate.o \
 	    Taxi.hi Taxi.o \
 	    node1/node.hs node2/node.hs node3/node.hs \
+	    node1/node.hi node2/node.hi node3/node.hi \
+	    node1/node.o node2/node.o node3/node.o \
 	    node1/Taxi.hs node2/Taxi.hs node3/Taxi.hs \
 	    node1/Dockerfile node2/Dockerfile node3/Dockerfile
 	-test ! -d node2 || rmdir node2

--- a/examples/taxi/generate.hs
+++ b/examples/taxi/generate.hs
@@ -14,6 +14,7 @@ opts = GenerateOpts { imports = [ "Striot.FunctionalIoTtypes"
                                 , "Data.Maybe" -- fromJust
                                 , "Data.List.Split" -- splitOn
                                 , "Control.Concurrent"
+                                , "Control.Arrow" -- >>>
                                 ] -- threadDelay
                     , packages = []
                     , preSource = Just "preSource"

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -305,7 +305,7 @@ expandMap (Connect (Vertex e@(StreamVertex i Expand _ t1 _))
                    (Vertex m@(StreamVertex j Map (f:s:[]) _ t4))) =
     let t5 = "[" ++ t4 ++ "]"
         m2 = StreamVertex i Map ["map ("++f++")",s] t1 t5
-        e2 = StreamVertex j Expand [] t5 t4
+        e2 = StreamVertex j Expand ["s"] t5 t4
     in  Just (replaceVertex m e2 . replaceVertex e m2)
 
 expandMap _ = Nothing
@@ -318,7 +318,7 @@ expandMapPre =
 expandMapPost =
     Vertex (StreamVertex 0 Map ["map (show)","s"] "[Int]" "[String]")
     `Connect`
-    Vertex (StreamVertex 1 Expand [] "[String]" "String")
+    Vertex (StreamVertex 1 Expand ["s"] "[String]" "String")
 
 test_expandMap = assertEqual (applyRule expandMap expandMapPre) expandMapPost
 

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -233,7 +233,7 @@ test_mapScan = assertEqual (applyRule mapScan mapScanPre) mapScanPost
 expandFilter :: RewriteRule
 expandFilter (Connect (Vertex e@(StreamVertex j Expand [s] t1 t2))
                       (Vertex f@(StreamVertex i Filter (p:s':[]) _ _))) =
-    let m = StreamVertex j Map ["filter ("++p++")",s] t1 t1
+    let m = StreamVertex j Map ["(filter ("++p++"))",s] t1 t1
         e'= StreamVertex i Expand [s'] t1 t2
     in  Just (replaceVertex f e' . replaceVertex e m)
 expandFilter _ = Nothing
@@ -243,7 +243,7 @@ expandFilterPre =
     `Connect`
     Vertex (StreamVertex 2 Filter ["p","bar"] "Int" "Int")
 expandFilterPost =
-    Vertex (StreamVertex 1 Map ["filter (p)", "foo"] "[Int]" "[Int]")
+    Vertex (StreamVertex 1 Map ["(filter (p))", "foo"] "[Int]" "[Int]")
     `Connect`
     Vertex (StreamVertex 2 Expand ["bar"] "[Int]" "Int")
 


### PR DESCRIPTION
This implements all the rewrite rules from the draft paper except for

 * any involving join or merge: since we need edge labelling (or a different representation from graphs) to handle those
 * `window w → expand → window w`: we can't use a single pattern match for such a sub-graph