### PR TITLE
Sync version constrains from cabal and stack files

### DIFF
--- a/striot.cabal
+++ b/striot.cabal
@@ -25,7 +25,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:      base              >= 4.9
-                    , network           >= 3.0.0.0
+                    , network           >= 3.1.0.0
                     , containers        >= 0.5
                     , split             >= 0.2
                     , time              >= 1.6
@@ -36,9 +36,9 @@ library
                     , filepath          >= 1.4
                     , directory         >= 1.3
                     , store
-                    , store-streaming
+                    , store-streaming   >= 0.1.0
                     , async
-                    , prometheus        >= 2.0.0
+                    , prometheus        >= 2.1.2
                     , text
                     , process
   hs-source-dirs:     src
@@ -49,7 +49,7 @@ test-suite test-striot
   type:               exitcode-stdio-1.0
   main-is:            TestMain.hs
   build-depends:      base              >= 4.9
-                    , network           >= 3.0.0.0
+                    , network           >= 3.1.0.0
                     , containers        >= 0.5
                     , split             >= 0.2
                     , time              >= 1.6
@@ -60,9 +60,9 @@ test-suite test-striot
                     , filepath          >= 1.4
                     , directory         >= 1.3
                     , store
-                    , store-streaming
+                    , store-streaming   >= 0.1.0
                     , async
-                    , prometheus        >= 2.0.0
+                    , prometheus        >= 2.1.2
                     , text
                     , process
   other-modules:      Striot.CompileIoT


### PR DESCRIPTION
I noticed the version constraint in stack.yaml and striot.cabal for network were different, so I've synced the versions from the stack file into the cabal file.

If we bumped to lts-14.20, we could save a single line of extra-deps from stack.yaml (unagi-uchan) but we would also need to bump the container version to align GHC versions and test a bunch of stuff, so i don't think it's worth doing at the moment.

If we did #66 we could possibly move to ghc-via-stack and stack-based builds in the container to make aligning versions easier.

Or stop using stack and use cabal v2/new-style builds; but stack is working for me at the moment.