### PR TITLE
Generic node functions

### DIFF
--- a/containers/Makefile
+++ b/containers/Makefile
@@ -6,7 +6,7 @@ readme = $(base)/README.md
 cabal = $(base)/striot.cabal
 
 src_dir := $(base)/src
-in_srcs := $(wildcard ../src/*.hs) $(wildcard ../src/**/*.hs)
+in_srcs := $(wildcard ../src/*.hs) $(wildcard ../src/**/*.hs) $(wildcard ../src/**/**/*.hs)
 out_srcs := $(subst ..,$(base),$(in_srcs))
 
 .PHONY: all

--- a/examples/pipeline-kafka/docker-compose.yml
+++ b/examples/pipeline-kafka/docker-compose.yml
@@ -24,6 +24,17 @@ services:
       - "9001"
     stdin_open: true
     tty: true
+    environment:
+      STRIOT_NODE_NAME: striot-link
+      STRIOT_INGRESS_TYPE: KAFKA
+      STRIOT_INGRESS_HOST: kafka
+      STRIOT_INGRESS_PORT: 9092
+      STRIOT_INGRESS_KAFKA_TOPIC: striot-queue
+      STRIOT_INGRESS_KAFKA_CON_GROUP: striot_con_group
+      STRIOT_EGRESS_TYPE: TCP
+      STRIOT_EGRESS_HOST: node3
+      STRIOT_EGRESS_PORT: 9001
+      STRIOT_CHAN_SIZE: 10
     depends_on:
       - kafka
       - node3
@@ -31,6 +42,17 @@ services:
     build: node1
     stdin_open: true
     tty: true
+    environment:
+      STRIOT_NODE_NAME: striot-source
+      STRIOT_INGRESS_TYPE: TCP
+      STRIOT_INGRESS_HOST: ""
+      STRIOT_INGRESS_PORT: ""
+      STRIOT_EGRESS_TYPE: KAFKA
+      STRIOT_EGRESS_HOST: kafka
+      STRIOT_EGRESS_PORT: 9092
+      STRIOT_EGRESS_KAFKA_TOPIC: striot-queue
+      STRIOT_EGRESS_KAFKA_CON_GROUP: none
+      STRIOT_CHAN_SIZE: 10
     depends_on:
       - kafka
       - node2

--- a/examples/pipeline-kafka/node1/node.hs
+++ b/examples/pipeline-kafka/node1/node.hs
@@ -2,6 +2,8 @@
 import Striot.FunctionalIoTtypes
 import Striot.FunctionalProcessing
 import Striot.Nodes
+import Striot.Nodes.Types
+import System.Envy
 import Control.Concurrent
 
 
@@ -17,4 +19,7 @@ streamGraphFn n1 = let
 
 main :: IO ()
 main = do
-       nodeSourceKafka src1 streamGraphFn "node1" "kafka" "9092"
+    conf <- decodeEnv :: IO (Either String StriotConfig)
+    case conf of
+        Left _  -> print "Could not read from env"
+        Right c -> nodeSource c src1 streamGraphFn

--- a/examples/pipeline-kafka/node2/node.hs
+++ b/examples/pipeline-kafka/node2/node.hs
@@ -2,6 +2,8 @@
 import Striot.FunctionalIoTtypes
 import Striot.FunctionalProcessing
 import Striot.Nodes
+import Striot.Nodes.Types
+import System.Envy
 import Control.Concurrent
 
 
@@ -12,4 +14,8 @@ streamGraphFn n1 = let
 
 
 main :: IO ()
-main = nodeLinkKafka streamGraphFn "node2" "kafka" "9092" "node3" "9001"
+main = do
+    conf <- decodeEnv :: IO (Either String StriotConfig)
+    case conf of
+        Left _  -> print "Could not read from env"
+        Right c -> nodeLink c streamGraphFn

--- a/examples/pipeline-kafka/node3/node.hs
+++ b/examples/pipeline-kafka/node3/node.hs
@@ -17,4 +17,4 @@ streamGraphFn n1 = let
 
 
 main :: IO ()
-main = nodeSink streamGraphFn sink1 "9001"
+main = nodeSink (defaultSink "9001") streamGraphFn sink1

--- a/examples/pipeline-mqtt/docker-compose.yml
+++ b/examples/pipeline-mqtt/docker-compose.yml
@@ -16,11 +16,31 @@ services:
       - "9001"
     stdin_open: true
     tty: true
+    environment:
+      STRIOT_NODE_NAME: striot-link
+      STRIOT_INGRESS_TYPE: MQTT
+      STRIOT_INGRESS_HOST: mqtt
+      STRIOT_INGRESS_PORT: 1883
+      STRIOT_INGRESS_MQTT_TOPIC: StriotQueue
+      STRIOT_EGRESS_TYPE: TCP
+      STRIOT_EGRESS_HOST: node3
+      STRIOT_EGRESS_PORT: 9001
+      STRIOT_CHAN_SIZE: 10
     depends_on:
       - mqtt
       - node3
   node1:
     build: node1
+    environment:
+      STRIOT_NODE_NAME: striot-source
+      STRIOT_INGRESS_TYPE: TCP
+      STRIOT_INGRESS_HOST: ""
+      STRIOT_INGRESS_PORT: ""
+      STRIOT_EGRESS_TYPE: MQTT
+      STRIOT_EGRESS_HOST: mqtt
+      STRIOT_EGRESS_PORT: 1883
+      STRIOT_EGRESS_MQTT_TOPIC: StriotQueue
+      STRIOT_CHAN_SIZE: 10
     depends_on:
       - mqtt
       - node2

--- a/examples/pipeline-mqtt/node1/node.hs
+++ b/examples/pipeline-mqtt/node1/node.hs
@@ -2,6 +2,8 @@
 import Striot.FunctionalIoTtypes
 import Striot.FunctionalProcessing
 import Striot.Nodes
+import Striot.Nodes.Types
+import System.Envy
 import Control.Concurrent
 
 
@@ -17,4 +19,7 @@ streamGraphFn n1 = let
 
 main :: IO ()
 main = do
-       nodeSourceMqtt src1 streamGraphFn "node1" "mqtt" "1883"
+    conf <- decodeEnv :: IO (Either String StriotConfig)
+    case conf of
+        Left _  -> print "Could not read from env"
+        Right c -> nodeSource c src1 streamGraphFn

--- a/examples/pipeline-mqtt/node2/node.hs
+++ b/examples/pipeline-mqtt/node2/node.hs
@@ -2,6 +2,8 @@
 import Striot.FunctionalIoTtypes
 import Striot.FunctionalProcessing
 import Striot.Nodes
+import Striot.Nodes.Types
+import System.Envy
 import Control.Concurrent
 
 
@@ -12,4 +14,8 @@ streamGraphFn n1 = let
 
 
 main :: IO ()
-main = nodeLinkMqtt streamGraphFn "node2" "mqtt" "1883" "node3" "9001"
+main = do
+    conf <- decodeEnv :: IO (Either String StriotConfig)
+    case conf of
+        Left _  -> print "Could not read from env"
+        Right c -> nodeLink c streamGraphFn

--- a/examples/pipeline-mqtt/node3/node.hs
+++ b/examples/pipeline-mqtt/node3/node.hs
@@ -17,4 +17,4 @@ streamGraphFn n1 = let
 
 
 main :: IO ()
-main = nodeSink streamGraphFn sink1 "9001"
+main = nodeSink (defaultSink "9001") streamGraphFn sink1

--- a/examples/pipeline/docker-compose.yml
+++ b/examples/pipeline/docker-compose.yml
@@ -1,14 +1,20 @@
 node3:
-  build: node3
-  stdin_open: true
-  tty: true
+    build: node3
+    stdin_open: true
+    tty: true
+    ports:
+      - "8082:8080"
 node2:
-  build: node2
-  links:
-    - node3
-  stdin_open: true
-  tty: true
+    build: node2
+    links:
+      - node3
+    stdin_open: true
+    tty: true
+    ports:
+      - "8081:8080"
 node1:
-  build: node1
-  links:
-    - node2
+    build: node1
+    links:
+      - node2
+    ports:
+      - "8080:8080"

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -183,7 +183,7 @@ generateSinkFn sg = "sink1 :: Show a => Stream a -> IO ()\nsink1 = " ++
     (intercalate "\n" $ parameters $ head $ reverse $ vertexList sg) ++ "\n"
 
 generateNodeLink :: Integer -> String
-generateNodeLink n = "main = nodeLink streamGraphFn \"9001\" \"node"++(show n)++"\" \"9001\""
+generateNodeLink n = "main = nodeLink (defaultLink \"9001\" \"node"++(show n)++"\" \"9001\") streamGraphFn"
 
 -- warts:
 --  we accept a list of onward nodes but nodeSource only accepts one anyway
@@ -198,11 +198,11 @@ generateNodeSrc partId nodes opts = let
 
     in "main = do\n\
 \       "++pref++"\n\
-\       nodeSource src1 streamGraphFn \""++host++"\" \""++(show port)++"\""
+\       nodeSource (defaultSource \""++host++"\" \""++(show port)++"\") src1 streamGraphFn"
 
 generateNodeSink :: Int -> String
 generateNodeSink v = case v of
-    1 -> "main = nodeSink streamGraphFn sink1 \"9001\""
+    1 -> "main = nodeSink (defaultSink \"9001\") streamGraphFn sink1"
     2 -> "main = nodeSink2 streamGraphFn sink1 \"9001\" \"9002\""
     v -> error "generateNodeSink: unhandled valence " ++ (show v)
 

--- a/src/Striot/Nodes.hs
+++ b/src/Striot/Nodes.hs
@@ -5,110 +5,86 @@ module Striot.Nodes ( nodeSink
                     , nodeLink
                     , nodeLink2
                     , nodeSource
-                    , nodeSourceMqtt
-                    , nodeLinkMqtt
-                    , nodeSourceKafka
-                    , nodeLinkKafka
+                    , defaultConfig
                     ) where
 
-import           Control.Concurrent                            (forkFinally,
-                                                                threadDelay)
 import           Control.Concurrent.Async                      (async)
 import           Control.Concurrent.Chan.Unagi.Bounded         as U
-import           Control.Concurrent.STM
-import qualified Control.Exception                             as E (bracket,
-                                                                     catch,
-                                                                     evaluate)
-import           Control.Monad                                 (forever, unless,
-                                                                when, void)
-import           Control.Monad.Reader
-import           Control.Monad.IO.Class
-import           Control.DeepSeq                               (force)
 import           Control.Lens
-import qualified Data.ByteString                               as B (ByteString,
-                                                                     length,
-                                                                     null)
-import qualified Data.ByteString.Lazy.Char8                    as BLC
+import           Control.Monad.IO.Class
+import           Control.Monad.Reader
 import           Data.IORef
 import           Data.Maybe
-import           Data.Store                                    (Store, encode, decode)
-import qualified Data.Store.Streaming                          as SS
-import           Data.Text                                     as T (Text, pack)
+import           Data.Store                                    (Store)
+import           Data.Text                                     as T (pack)
 import           Data.Time                                     (getCurrentTime)
-import           Network.MQTT.Client as MQTT hiding            (Timeout)
-import           Network.MQTT.Types                            (RetainHandling(..))
-import           Network.Socket
-import           Network.Socket.ByteString
-import           Network.URI                                   (parseURI)
+import           Network.Socket                                (HostName,
+                                                                ServiceName)
 import           Striot.FunctionalIoTtypes
-import           System.Exit                                   (exitFailure)
-import           Striot.Nodes.Types as NT
+import           Striot.Nodes.Kafka
+import           Striot.Nodes.MQTT
+import           Striot.Nodes.TCP
+import           Striot.Nodes.Types                            hiding (nc,
+                                                                readConf,
+                                                                writeConf)
 import           System.IO
-import           System.IO.ByteBuffer                          as BB
 import           System.IO.Unsafe
 import           System.Metrics.Prometheus.Concurrent.Registry as PR (new, registerCounter,
                                                                       registerGauge,
                                                                       sample)
 import           System.Metrics.Prometheus.Http.Scrape         (serveHttpTextMetrics)
-import           System.Metrics.Prometheus.Metric.Counter      as PC (add, inc)
-import           System.Metrics.Prometheus.Metric.Gauge        as PG (dec, inc)
+import           System.Metrics.Prometheus.Metric.Counter      as PC (inc)
 import           System.Metrics.Prometheus.MetricId            (addLabel)
-import           Kafka.Producer                                as KP
-import           Kafka.Consumer                                as KC
 
 
---- SINK FUNCTIONS ---
+-- NODE FUNCTIONS
 
-nodeSink :: (Store alpha, Store beta)
-         => (Stream alpha -> Stream beta)
-         -> (Stream beta -> IO ())
-         -> ServiceName
-         -> IO ()
-nodeSink streamOp iofn inputPort = do
-    sock <- listenSocket inputPort
-    metrics <- startPrometheus "node-sink"
-    putStrLn "Starting server ..."
-    stream <- processSocket metrics sock
+nodeSource :: (Store alpha, Store beta)
+           => StriotConfig
+           -> IO alpha
+           -> (Stream alpha -> Stream beta)
+           -> IO ()
+nodeSource config iofn streamOp =
+    runReaderT (unApp $ nodeSource' iofn streamOp) config
+
+
+nodeSource' :: (Store alpha, Store beta,
+               MonadReader r m,
+               HasStriotConfig r,
+               MonadIO m)
+            => IO alpha
+            -> (Stream alpha -> Stream beta) -> m ()
+nodeSource' iofn streamOp = do
+    c <- ask
+    metrics <- liftIO $ startPrometheus (c ^. nodeName)
+    stream <- liftIO $ readListFromSource iofn metrics
     let result = streamOp stream
-    iofn result
+    sendStream metrics result
 
-
--- A Sink with 2 inputs
-nodeSink2 :: (Store alpha, Store beta, Store gamma)
-          => (Stream alpha -> Stream beta -> Stream gamma)
-          -> (Stream gamma -> IO ())
-          -> ServiceName
-          -> ServiceName
-          -> IO ()
-nodeSink2 streamOp iofn inputPort1 inputPort2 = do
-    sock1 <- listenSocket inputPort1
-    sock2 <- listenSocket inputPort2
-    metrics <- startPrometheus "node-sink"
-    putStrLn "Starting server ..."
-    stream1 <- processSocket metrics sock1
-    stream2 <- processSocket metrics sock2
-    let result = streamOp stream1 stream2
-    iofn result
-
-
---- LINK FUNCTIONS ---
 
 nodeLink :: (Store alpha, Store beta)
-         => (Stream alpha -> Stream beta)
-         -> ServiceName
-         -> HostName
-         -> ServiceName
+         => StriotConfig
+         -> (Stream alpha -> Stream beta)
          -> IO ()
-nodeLink streamOp inputPort outputHost outputPort = do
-    sock <- listenSocket inputPort
-    metrics <- startPrometheus "node-link"
-    putStrLn "Starting link ..."
-    stream <- processSocket metrics sock
+nodeLink config streamOp =
+    runReaderT (unApp $ nodeLink' streamOp) config
+
+
+nodeLink' :: (Store alpha, Store beta,
+             MonadReader r m,
+             HasStriotConfig r,
+             MonadIO m)
+          => (Stream alpha -> Stream beta)
+          -> m ()
+nodeLink' streamOp = do
+    c <- ask
+    metrics <- liftIO $ startPrometheus (c ^. nodeName)
+    stream <- processInput metrics
     let result = streamOp stream
-    sendStreamTCP result metrics outputHost outputPort
+    sendStream metrics result
 
 
--- A Link with 2 inputs
+-- {- Old style configless link with 2 inputs }
 nodeLink2 :: (Store alpha, Store beta, Store gamma)
           => (Stream alpha -> Stream beta -> Stream gamma)
           -> ServiceName
@@ -117,159 +93,128 @@ nodeLink2 :: (Store alpha, Store beta, Store gamma)
           -> ServiceName
           -> IO ()
 nodeLink2 streamOp inputPort1 inputPort2 outputHost outputPort = do
-    sock1 <- listenSocket inputPort1
-    sock2 <- listenSocket inputPort2
-    metrics <- startPrometheus "node-link"
+    let nodeName = "node-link"
+        (ConnTCPConfig ic1) = tcpConfig "" inputPort1
+        (ConnTCPConfig ic2) = tcpConfig "" inputPort2
+        (ConnTCPConfig ec)  = tcpConfig outputHost outputPort
+    metrics <- startPrometheus nodeName
     putStrLn "Starting link ..."
-    stream1 <- processSocket metrics sock1
-    stream2 <- processSocket metrics sock2
+    stream1 <- processSocket nodeName ic1 metrics
+    stream2 <- processSocket nodeName ic2 metrics
     let result = streamOp stream1 stream2
-    sendStreamTCP result metrics outputHost outputPort
+    sendStreamTCP nodeName ec metrics result
 
 
---- SOURCE FUNCTIONS ---
-
-nodeSource :: Store beta
-           => IO alpha
-           -> (Stream alpha -> Stream beta)
-           -> HostName
-           -> ServiceName
-           -> IO ()
-nodeSource pay streamGraph host port = do
-    metrics <- startPrometheus "node-source"
-    putStrLn "Starting source ..."
-    stream <- readListFromSource pay metrics
-    let result = streamGraph stream
-    sendStreamTCP result metrics host port
-    -- or printStream if it's a completely self contained streamGraph
+nodeSink :: (Store alpha, Store beta)
+         => StriotConfig
+         -> (Stream alpha -> Stream beta)
+         -> (Stream beta -> IO ())
+         -> IO ()
+nodeSink config streamOp iofn =
+    runReaderT (unApp $ nodeSink' streamOp iofn) config
 
 
---- MQTT FUNCTIONS ---
-
--- nodeSourceMqtt :: Store beta
---                => IO alpha
---                -> (Stream alpha -> Stream beta)
---                -> String
---                -> HostName
---                -> ServiceName
---                -> IO ()
--- nodeSourceMqtt pay streamOp nodeName host port = do
---     metrics <- startPrometheus nodeName
---     putStrLn "Starting source ..."
---     stream <- readListFromSource pay metrics
---     let result = streamOp stream
---     sendStreamMQTT result metrics nodeName host port
+nodeSink' :: (Store alpha, Store beta,
+             MonadReader r m,
+             HasStriotConfig r,
+             MonadIO m)
+          => (Stream alpha -> Stream beta)
+          -> (Stream beta -> IO ())
+          -> m ()
+nodeSink' streamOp iofn = do
+    c <- ask
+    metrics <- liftIO $ startPrometheus (c ^. nodeName)
+    stream <- processInput metrics
+    let result = streamOp stream
+    liftIO $ iofn result
 
 
--- nodeLinkMqtt :: (Store alpha, Store beta)
---              => (Stream alpha -> Stream beta)
---              -> String
---              -> HostName
---              -> ServiceName
---              -> HostName
---              -> ServiceName
---              -> IO ()
--- nodeLinkMqtt streamOp nodeName inputHost inputPort outputHost outputPort = do
---     metrics <- startPrometheus nodeName
---     putStrLn "Starting link ..."
---     stream <- processSocketMQTT metrics nodeName inputHost inputPort
---     let result = streamOp stream
---     sendStreamTCP result metrics outputHost outputPort
+-- {- Old style configless sink with 2 inputs }
+nodeSink2 :: (Store alpha, Store beta, Store gamma)
+          => (Stream alpha -> Stream beta -> Stream gamma)
+          -> (Stream gamma -> IO ())
+          -> ServiceName
+          -> ServiceName
+          -> IO ()
+nodeSink2 streamOp iofn inputPort1 inputPort2 = do
+    let nodeName = "node-sink"
+        (ConnTCPConfig ic1) = tcpConfig "" inputPort1
+        (ConnTCPConfig ic2) = tcpConfig "" inputPort2
+    metrics <- startPrometheus nodeName
+    putStrLn "Starting sink ..."
+    stream1 <- processSocket nodeName ic1 metrics
+    stream2 <- processSocket nodeName ic2 metrics
+    let result = streamOp stream1 stream2
+    iofn result
 
-
---- KAFKA FUNCTIONS ---
-
--- nodeSourceKafka :: Store beta
---                 => IO alpha
---                 -> (Stream alpha -> Stream beta)
---                 -> String
---                 -> HostName
---                 -> ServiceName
---                 -> IO ()
--- nodeSourceKafka pay streamOp nodeName host port = do
---     metrics <- startPrometheus nodeName
---     putStrLn "Starting source ..."
---     stream <- readListFromSource pay metrics
---     let result = streamOp stream
---     sendStreamKafka result metrics nodeName host (read port)
-
-
--- nodeLinkKafka :: (Store alpha, Store beta)
---               => (Stream alpha -> Stream beta)
---               -> String
---               -> HostName
---               -> ServiceName
---               -> HostName
---               -> ServiceName
---               -> IO ()
--- nodeLinkKafka streamOp nodeName inputHost inputPort outputHost outputPort = do
---     metrics <- startPrometheus nodeName
---     putStrLn "Starting link ..."
---     stream <- processSocketKafka metrics nodeName inputHost (read inputPort)
---     let result = streamOp stream
---     sendStreamTCP result metrics outputHost outputPort
 
 --- CONFIG FUNCTIONS ---
 
--- defaultConfig :: ServiceName -> HostName -> ServiceName -> StriotConfig
--- defaultConfig inPort outHost outPort = baseConfig (tcpConfig "" inPort) (tcpConfig outHost outPort)
-
--- baseConfig :: ConnectionConfig -> ConnectionConfig -> StriotConfig
--- baseConfig icc ecc = StriotConfig "" icc ecc 10
-
--- tcpConfig :: HostName -> ServiceName -> ConnectionConfig
--- tcpConfig host port = ConnTCPConfig $ TCPConfig $ NetConfig host port
-
--- mqttConfig :: String -> HostName -> ServiceName -> ConnectionConfig
--- mqttConfig topic host port = ConnMQTTConfig $ NT.MQTTConfig { _mqttConn  = NetConfig host port
---                                                             , _mqttTopic = topic }
-
--- defaultMqttConfig :: HostName -> ServiceName -> ConnectionConfig
--- defaultMqttConfig = mqttConfig "StriotQueue"
-
--- NEW NODE FUNCTIONS
-
-nodeLinkNew :: (Store alpha, Store beta)
-            => StriotConfig
-            -> (Stream alpha -> Stream beta)
-            -> IO ()
-nodeLinkNew config streamOp = do
-    ref <- newIORef Metrics {}
-    let conf = set met ref config
-    runReaderT (unApp $ nodeInternal streamOp) conf
+defaultConfig :: String -> HostName -> ServiceName -> HostName -> ServiceName -> StriotConfig
+defaultConfig = defaultConfig' TCP TCP
 
 
-nodeInternal :: (Store alpha, Store beta,
-                MonadReader r m,
-                HasStriotConfig r,
-                MonadIO m)
-             => (Stream alpha -> Stream beta) -> m ()
-nodeInternal streamOp = do
-    c <- ask
-    liftIO $ writeIORef (c ^. met) =<< startPrometheus (c ^. nodeName)
-    stream <- processInput
-    let result = streamOp stream
-    sendStream result
+defaultConfig' :: ConnectProtocol -> ConnectProtocol -> String -> HostName -> ServiceName -> HostName -> ServiceName -> StriotConfig
+defaultConfig' ict ect nn inHost inPort outHost outPort =
+    let ccf ct = case ct of
+                    TCP   -> tcpConfig
+                    KAFKA -> defaultKafkaConfig
+                    MQTT  -> defaultMqttConfig
+    in  baseConfig nn ((ccf ict) inHost inPort) ((ccf ect) outHost outPort)
+
+
+baseConfig :: String -> ConnectionConfig -> ConnectionConfig -> StriotConfig
+baseConfig nn icc ecc =
+    StriotConfig
+        { _nodeName          = nn
+        , _ingressConnConfig = icc
+        , _egressConnConfig  = ecc
+        , _chanSize          = 10
+        }
+
+
+tcpConfig :: HostName -> ServiceName -> ConnectionConfig
+tcpConfig host port =
+    ConnTCPConfig $ TCPConfig $ NetConfig host port
+
+
+kafkaConfig :: String -> String -> HostName -> ServiceName -> ConnectionConfig
+kafkaConfig topic conGroup host port =
+    ConnKafkaConfig $ KafkaConfig (NetConfig host port) topic conGroup
+
+
+defaultKafkaConfig :: HostName -> ServiceName -> ConnectionConfig
+defaultKafkaConfig = kafkaConfig "striot-queue" "striot_consumer_group"
+
+
+mqttConfig :: String -> HostName -> ServiceName -> ConnectionConfig
+mqttConfig topic host port =
+    ConnMQTTConfig $ MQTTConfig (NetConfig host port) topic
+
+
+defaultMqttConfig :: HostName -> ServiceName -> ConnectionConfig
+defaultMqttConfig = mqttConfig "StriotQueue"
 
 
 processInput :: (Store alpha,
                 MonadReader r m,
                 HasStriotConfig r,
                 MonadIO m)
-             => m (Stream alpha)
-processInput = connectDispatch >>= (liftIO . U.getChanContents)
+             => Metrics
+             -> m (Stream alpha)
+processInput metrics = connectDispatch metrics >>= (liftIO . U.getChanContents)
 
 
 connectDispatch :: (Store alpha,
                    MonadReader r m,
                    HasStriotConfig r,
                    MonadIO m)
-                => m (U.OutChan (Event alpha))
-connectDispatch = do
+                => Metrics
+                -> m (U.OutChan (Event alpha))
+connectDispatch metrics = do
     c <- ask
     liftIO $ do
         (inChan, outChan) <- U.newChan (c ^. chanSize)
-        metrics <- readIORef $ c ^. met
         async $ connectDispatch' (c ^. nodeName)
                                  (c ^. ingressConnConfig)
                                  metrics
@@ -290,20 +235,19 @@ connectDispatch' nodeName (ConnMQTTConfig  cc) met chan = liftIO $ runMQTTSub   
 
 
 sendStream :: (Store alpha,
-                 MonadReader r m,
-                 HasStriotConfig r,
-                 MonadIO m)
-              => Stream alpha
-              -> m ()
-sendStream stream = do
+              MonadReader r m,
+              HasStriotConfig r,
+              MonadIO m)
+           => Metrics
+           -> Stream alpha
+           -> m ()
+sendStream metrics stream = do
     c <- ask
-    liftIO $ do
-        metrics <- readIORef $ c ^. met
-        sendDispatch (c ^. nodeName)
-                     (c ^. egressConnConfig)
-                     metrics
-                     stream
-
+    liftIO
+        $ sendDispatch (c ^. nodeName)
+                       (c ^. egressConnConfig)
+                       metrics
+                       stream
 
 
 sendDispatch :: (Store alpha,
@@ -316,7 +260,6 @@ sendDispatch :: (Store alpha,
 sendDispatch nodeName (ConnTCPConfig   cc) met stream = liftIO $ sendStreamTCP   nodeName cc met stream
 sendDispatch nodeName (ConnKafkaConfig cc) met stream = liftIO $ sendStreamKafka nodeName cc met stream
 sendDispatch nodeName (ConnMQTTConfig  cc) met stream = liftIO $ sendStreamMQTT  nodeName cc met stream
-
 
 
 --- UTILITY FUNCTIONS ---
@@ -333,107 +276,6 @@ readListFromSource = go
         msg = do
             now <- getCurrentTime
             Event (Just now) . Just <$> pay
-
-
--- ==========================================================================
-{- processSocket is a wrapper function that handles concurrently
-accepting and handling connections on the socket and reading all of the strings
-into an event Stream -}
--- processSocket :: Store alpha => Metrics -> Socket -> IO (Stream alpha)
--- processSocket met sock = U.getChanContents =<< acceptConnections met sock
-
-
--- {- acceptConnections takes a socket as an argument and spins up a new thread to
--- process the data received. The returned TChan object contains the data from
--- the socket -}
--- acceptConnections :: Store alpha => Metrics -> Socket -> IO (U.OutChan (Event alpha))
--- acceptConnections met sock = do
---     (inChan, outChan) <- U.newChan chanSize'
---     async $ connectionHandler met sock inChan
---     return outChan
-
-
--- {- We are using a bounded queue to prevent extreme memory usage when
--- input rate > consumption rate. This value may need to be increased to achieve
--- higher throughput when computation costs are low -}
--- chanSize' :: Int
--- chanSize' = 10
-
-
-{- connectionHandler sits accepting any new connections. Once accepted, a new
-thread is forked to read from the socket. The function then loops to accept any
-subsequent connections -}
-connectTCP :: Store alpha
-                  => String
-                  -> TCPConfig
-                  -> Metrics
-                  -> U.InChan (Event alpha)
-                  -> IO ()
-connectTCP _ conf met chan = do
-    sock <- listenSocket $ conf ^. tcpConn . port
-    forever $ do
-        (conn, _) <- accept sock
-        forkFinally (PG.inc (_ingressConn met)
-                    >> processData met conn chan)
-                    (\_ -> PG.dec (_ingressConn met)
-                        >> close conn)
-
-
-{- processData takes a Socket and UChan. All of the events are read through
-use of a ByteBuffer and recv. The events are decoded by using store-streaming
-and added to the chan  -}   
-processData :: Store alpha => Metrics -> Socket -> U.InChan (Event alpha) -> IO ()
-processData met conn eventChan =
-    BB.with Nothing $ \buffer -> forever $ do
-        event <- decodeMessageBS' met buffer (readFromSocket conn)
-        case event of
-            Just m  -> do
-                        PC.inc (_ingressEvents met)
-                        U.writeChan eventChan $ SS.fromMessage m
-            Nothing -> print "decode failed"
-
-
-{- This is a rewrite of Data.Store.Streaming decodeMessageBS, passing in
-Metrics so that we can calculate ingressBytes while decoding -}
-decodeMessageBS' :: Store a
-                 => Metrics -> BB.ByteBuffer
-                 -> IO (Maybe B.ByteString) -> IO (Maybe (SS.Message a))
-decodeMessageBS' met = SS.decodeMessage (\bb _ bs -> PC.add (B.length bs)
-                                                            (_ingressBytes met)
-                                                     >> BB.copyByteString bb bs)
-
-
-{- Read up to 4096 bytes from the socket at a time, packing into a Maybe
-structure. As we use TCP sockets recv should block, and so if msg is empty
-the connection has been closed -}
-readFromSocket :: Socket -> IO (Maybe B.ByteString)
-readFromSocket conn = do
-    msg <- recv conn 4096
-    if B.null msg
-        then error "Upstream connection closed"
-        else return $ Just msg
-
-
-{- Connects to socket within a bracket to ensure the socket is closed if an
-exception occurs -}
-sendStreamTCP :: Store alpha => String -> TCPConfig -> Metrics -> Stream alpha -> IO ()
-sendStreamTCP _ _    _   []     = return ()
-sendStreamTCP _ conf met stream =
-    E.bracket (PG.inc (_egressConn met)
-               >> connectSocket (conf ^. tcpConn . host) (conf ^. tcpConn . port))
-              (\conn -> PG.dec (_egressConn met)
-                        >> close conn)
-              (\conn -> writeSocket conn met stream)
-
-
-{- Encode messages and send over the socket -}
-writeSocket :: Store alpha => Socket -> Metrics -> Stream alpha -> IO ()
-writeSocket conn met =
-    mapM_ (\event ->
-            let val = SS.encodeMessage . SS.Message $ event
-            in  PC.inc (_egressEvents met)
-                >> PC.add (B.length val) (_egressBytes met)
-                >> sendAll conn val)
 
 
 --- PROMETHEUS ---
@@ -456,224 +298,3 @@ startPrometheus nodeName = do
                    , _egressConn    = egressConn
                    , _egressBytes   = egressBytes
                    , _egressEvents  = egressEvents }
-
-
---- SOCKETS ---
-
-listenSocket :: ServiceName -> IO Socket
-listenSocket port = do
-    let hints = defaultHints { addrFlags = [AI_PASSIVE],
-                               addrSocketType = Stream }
-    (sock, addr) <- createSocket [] port hints
-    setSocketOption sock ReuseAddr 1
-    bind sock $ addrAddress addr
-    listen sock maxQConn
-    return sock
-    where maxQConn = 10
-
-
-connectSocket :: HostName -> ServiceName -> IO Socket
-connectSocket host port = do
-    let hints = defaultHints { addrSocketType = Stream }
-    (sock, addr) <- createSocket host port hints
-    setSocketOption sock KeepAlive 1
-    connect sock $ addrAddress addr
-    return sock
-
-
-createSocket :: HostName -> ServiceName -> AddrInfo -> IO (Socket, AddrInfo)
-createSocket host port hints = do
-    addr <- resolve host port hints
-    sock <- getSocket addr
-    return (sock, addr)
-  where
-    resolve host' port' hints' = do
-        addr:_ <- getAddrInfo (Just hints') (isHost host') (Just port')
-        return addr
-    getSocket addr = socket (addrFamily addr)
-                            (addrSocketType addr)
-                            (addrProtocol addr)
-    isHost h
-        | null h    = Nothing
-        | otherwise = Just h
-
-
---- MQTT ---
-
--- processSocketMqtt :: Store alpha => Metrics -> String -> HostName -> ServiceName -> IO (Stream alpha)
--- processSocketMqtt met nodeName host port = U.getChanContents =<< acceptConnectionsMqtt met nodeName host port
-
-
--- acceptConnectionsMqtt :: Store alpha => Metrics -> String -> HostName -> ServiceName -> IO (U.OutChan (Event alpha))
--- acceptConnectionsMqtt met nodeName host port = do
---     (inChan, outChan) <- U.newChan chanSize'
---     async $ runMQTTSub met nodeName mqttTopics host port inChan
---     return outChan
-
-
-sendStreamMQTT :: Store alpha => String -> NT.MQTTConfig -> Metrics -> Stream alpha -> IO ()
-sendStreamMQTT nodeName conf met stream = do
-    mc <- runMQTTPub nodeName (conf ^. mqttConn . host) (conf ^. mqttConn . port)
-    mapM_ (\x -> do
-                    val <- E.evaluate . force . encode $ x
-                    PC.inc (_egressEvents met)
-                        >> PC.add (B.length val) (_egressBytes met)
-                        >> publishq mc (read $ conf ^. mqttTopic) (BLC.fromStrict val) False QoS0 []) stream
-
-
-runMQTTPub :: String -> HostName -> ServiceName -> IO MQTTClient
-runMQTTPub nodeName host port =
-    let (Just uri) = parseURI $ "mqtt://" ++ host ++ ":" ++ port
-    in  connectURI (netmqttConf nodeName host port NoCallback) uri
-
-
-runMQTTSub :: Store alpha => String -> NT.MQTTConfig -> Metrics -> U.InChan (Event alpha) -> IO ()
-runMQTTSub nodeName conf met chan = do
-    let h = conf ^. mqttConn . host
-        p = conf ^. mqttConn . port
-        (Just uri) = parseURI $ "mqtt://" ++ h ++ ":" ++ p
-    mc <- connectURI (netmqttConf nodeName h p (SimpleCallback $ mqttMessageCallback met chan)) uri
-    print =<< subscribe mc (map (\x -> (x, subOptions)) [read $ (conf ^. mqttTopic)]) []
-    waitForClient mc
-
-
-mqttMessageCallback :: Store alpha => Metrics -> U.InChan (Event alpha) -> MQTTClient -> Topic -> BLC.ByteString -> [Property] -> IO ()
-mqttMessageCallback met chan mc topic msg _ =
-    let bmsg = BLC.toStrict msg
-    in  PC.inc (_ingressEvents met)
-            >> PC.add (B.length bmsg) (_ingressBytes met)
-            >> case decode bmsg of
-                    Right event -> U.writeChan chan event
-                    Left  _     -> return ()
-
-
--- mqttTopics :: [Topic]
--- mqttTopics = ["StriotQueue"]
-
-
-netmqttConf :: String -> HostName -> ServiceName -> MessageCallback -> MQTT.MQTTConfig
-netmqttConf nodeName host port msgCB =
-    mqttConfig
-        { MQTT._hostname = host
-        , MQTT._port     = read port
-        , _connID        = nodeName
-        , _username      = Just "striot"
-        , _password      = Just "striot"
-        , _msgCB         = msgCB }
-
-
-mqttSubOptions :: SubOptions
-mqttSubOptions =
-    subOptions
-        { _retainHandling    = SendOnSubscribeNew
-        , _retainAsPublished = True
-        , _noLocal           = True
-        , _subQoS            = QoS0 }
-
-
---- KAFKA ---
-
-sendStreamKafka :: Store alpha => String -> KafkaConfig -> Metrics -> Stream alpha -> IO ()
-sendStreamKafka nodeName conf met stream =
-    E.bracket mkProducer clProducer runHandler >>= print
-        where
-          mkProducer              = PG.inc (_egressConn met)
-                                    >> print "create new producer"
-                                    >> newProducer (producerProps conf)
-          clProducer (Left _)     = print "error close producer"
-                                    >> return ()
-          clProducer (Right prod) = PG.dec (_egressConn met)
-                                    >> closeProducer prod
-                                    >> print "close producer"
-          runHandler (Left err)   = return $ Left err
-          runHandler (Right prod) = print "runhandler producer"
-                                    >> sendMessagesKafka prod (TopicName . read $ conf ^. kafkaTopic) stream met
-
-
-kafkaConnectDelayMs :: Int
-kafkaConnectDelayMs = 300000
-
-
-producerProps :: KafkaConfig -> ProducerProperties
-producerProps conf =
-    KP.brokersList [BrokerAddress $ brokerAddress conf]
-       <> KP.logLevel KafkaLogInfo
-
-
-sendMessagesKafka :: Store alpha => KafkaProducer -> TopicName -> Stream alpha -> Metrics -> IO (Either KafkaError ())
-sendMessagesKafka prod topic stream met = do
-    mapM_ (\x -> do
-            let val = encode x
-            produceMessage prod (mkMessage topic Nothing (Just val))
-                >> PC.inc (_egressEvents met)
-                >> PC.add (B.length val) (_egressBytes met)
-          ) stream
-    return $ Right ()
-
-
-mkMessage :: TopicName -> Maybe B.ByteString -> Maybe B.ByteString -> ProducerRecord
-mkMessage topic k v =
-    ProducerRecord
-        { prTopic     = topic
-        , prPartition = UnassignedPartition
-        , prKey       = k
-        , prValue     = v
-        }
-
-
--- defaultKafkaTopic :: TopicName
--- defaultKafkaTopic = TopicName "striot-queue"
-
-
--- processSocketKafka :: Store alpha => Metrics -> String -> HostName -> PortNumber -> IO (Stream alpha)
--- processSocketKafka met nodeName host port = U.getChanContents =<< runKafkaConsumer met nodeName host port
-
-
-runKafkaConsumer :: Store alpha => String -> KafkaConfig -> Metrics -> U.InChan (Event alpha) -> IO ()
-runKafkaConsumer nodeName conf met chan = E.bracket mkConsumer clConsumer (runHandler chan)
-    where
-        mkConsumer                 = PG.inc (_ingressConn met)
-                                     >> print "create new consumer"
-                                     >> newConsumer (consumerProps conf)
-                                                    (consumerSub $ TopicName . read $ conf ^. kafkaTopic) 
-        clConsumer      (Left err) = print "error close consumer"
-                                     >> return ()
-        clConsumer      (Right kc) = void $ closeConsumer kc
-                                          >> PG.dec (_ingressConn met)
-                                          >> print "close consumer"
-        runHandler _    (Left err) = print "error handler close consumer"
-                                     >> return ()
-        runHandler chan (Right kc) = print "runhandler consumer"
-                                     >> processKafkaMessages met kc chan
-
-
-processKafkaMessages :: Store alpha => Metrics -> KafkaConsumer -> U.InChan (Event alpha) -> IO ()
-processKafkaMessages met kc chan = forever $ do
-    threadDelay kafkaConnectDelayMs
-    msg <- pollMessage kc (Timeout 50)
-    either (\_ -> return ()) extractValue msg
-      where
-        extractValue m = maybe (print "kafka-error: crValue Nothing") writeRight (crValue m)
-        writeRight   v = either (\err -> print $ "decode-error: " ++ show err)
-                                (\x -> do
-                                    PC.inc (_ingressEvents met)
-                                        >> PC.add (B.length v) (_ingressBytes met)
-                                    U.writeChan chan x)
-                                (decode v)
-
-
-consumerProps :: KafkaConfig -> ConsumerProperties
-consumerProps conf =
-    KC.brokersList [BrokerAddress $ brokerAddress conf]
-         <> groupId (ConsumerGroupId . read $ conf ^. kafkaConGroup)
-         <> KC.logLevel KafkaLogInfo
-         <> KC.callbackPollMode CallbackPollModeSync
-
-
-consumerSub :: TopicName -> Subscription
-consumerSub topic = topics [topic]
-                    <> offsetReset Earliest
-
-
-brokerAddress :: KafkaConfig -> T.Text
-brokerAddress conf = T.pack $ (conf ^. kafkaConn . host) ++ ":" ++ (conf ^. kafkaConn . port)

--- a/src/Striot/Nodes/Kafka.hs
+++ b/src/Striot/Nodes/Kafka.hs
@@ -35,7 +35,7 @@ sendStreamKafka name conf met stream =
                                     >> print "close producer"
           runHandler (Left err)   = return $ Left err
           runHandler (Right prod) = print "runhandler producer"
-                                    >> sendMessagesKafka prod (TopicName . read $ conf ^. kafkaTopic) stream met
+                                    >> sendMessagesKafka prod (TopicName . T.pack $ conf ^. kafkaTopic) stream met
 
 
 kafkaConnectDelayMs :: Int
@@ -75,7 +75,7 @@ runKafkaConsumer name conf met chan = E.bracket mkConsumer clConsumer (runHandle
         mkConsumer                 = PG.inc (_ingressConn met)
                                      >> print "create new consumer"
                                      >> newConsumer (consumerProps conf)
-                                                    (consumerSub $ TopicName . read $ conf ^. kafkaTopic)
+                                                    (consumerSub $ TopicName . T.pack $ conf ^. kafkaTopic)
         clConsumer      (Left err) = print "error close consumer"
                                      >> return ()
         clConsumer      (Right kc) = void $ closeConsumer kc
@@ -105,7 +105,7 @@ processKafkaMessages met kc chan = forever $ do
 consumerProps :: KafkaConfig -> ConsumerProperties
 consumerProps conf =
     KC.brokersList [BrokerAddress $ brokerAddress conf]
-         <> groupId (ConsumerGroupId . read $ conf ^. kafkaConGroup)
+         <> groupId (ConsumerGroupId . T.pack $ conf ^. kafkaConGroup)
          <> KC.logLevel KafkaLogInfo
          <> KC.callbackPollMode CallbackPollModeSync
 

--- a/src/Striot/Nodes/Kafka.hs
+++ b/src/Striot/Nodes/Kafka.hs
@@ -1,0 +1,119 @@
+module Striot.Nodes.Kafka
+( sendStreamKafka
+, runKafkaConsumer
+) where
+
+import           Control.Concurrent                       (threadDelay)
+import           Control.Concurrent.Chan.Unagi.Bounded    as U
+import qualified Control.Exception                        as E (bracket)
+import           Control.Lens
+import           Control.Monad                            (forever, void)
+import qualified Data.ByteString                          as B (ByteString,
+                                                                length)
+import           Data.Store                               (Store, decode,
+                                                           encode)
+import           Data.Text                                as T (Text, pack)
+import           Kafka.Consumer                           as KC
+import           Kafka.Producer                           as KP
+import           Striot.FunctionalIoTtypes
+import           Striot.Nodes.Types
+import           System.Metrics.Prometheus.Metric.Counter as PC (add, inc)
+import           System.Metrics.Prometheus.Metric.Gauge   as PG (dec, inc)
+
+
+sendStreamKafka :: Store alpha => String -> KafkaConfig -> Metrics -> Stream alpha -> IO ()
+sendStreamKafka name conf met stream =
+    E.bracket mkProducer clProducer runHandler >>= print
+        where
+          mkProducer              = PG.inc (_egressConn met)
+                                    >> print "create new producer"
+                                    >> newProducer (producerProps conf)
+          clProducer (Left _)     = print "error close producer"
+                                    >> return ()
+          clProducer (Right prod) = PG.dec (_egressConn met)
+                                    >> closeProducer prod
+                                    >> print "close producer"
+          runHandler (Left err)   = return $ Left err
+          runHandler (Right prod) = print "runhandler producer"
+                                    >> sendMessagesKafka prod (TopicName . read $ conf ^. kafkaTopic) stream met
+
+
+kafkaConnectDelayMs :: Int
+kafkaConnectDelayMs = 300000
+
+
+producerProps :: KafkaConfig -> ProducerProperties
+producerProps conf =
+    KP.brokersList [BrokerAddress $ brokerAddress conf]
+       <> KP.logLevel KafkaLogInfo
+
+
+sendMessagesKafka :: Store alpha => KafkaProducer -> TopicName -> Stream alpha -> Metrics -> IO (Either KafkaError ())
+sendMessagesKafka prod topic stream met = do
+    mapM_ (\x -> do
+            let val = encode x
+            produceMessage prod (mkMessage topic Nothing (Just val))
+                >> PC.inc (_egressEvents met)
+                >> PC.add (B.length val) (_egressBytes met)
+          ) stream
+    return $ Right ()
+
+
+mkMessage :: TopicName -> Maybe B.ByteString -> Maybe B.ByteString -> ProducerRecord
+mkMessage topic k v =
+    ProducerRecord
+        { prTopic     = topic
+        , prPartition = UnassignedPartition
+        , prKey       = k
+        , prValue     = v
+        }
+
+
+runKafkaConsumer :: Store alpha => String -> KafkaConfig -> Metrics -> U.InChan (Event alpha) -> IO ()
+runKafkaConsumer name conf met chan = E.bracket mkConsumer clConsumer (runHandler chan)
+    where
+        mkConsumer                 = PG.inc (_ingressConn met)
+                                     >> print "create new consumer"
+                                     >> newConsumer (consumerProps conf)
+                                                    (consumerSub $ TopicName . read $ conf ^. kafkaTopic)
+        clConsumer      (Left err) = print "error close consumer"
+                                     >> return ()
+        clConsumer      (Right kc) = void $ closeConsumer kc
+                                          >> PG.dec (_ingressConn met)
+                                          >> print "close consumer"
+        runHandler _    (Left err) = print "error handler close consumer"
+                                     >> return ()
+        runHandler chan (Right kc) = print "runhandler consumer"
+                                     >> processKafkaMessages met kc chan
+
+
+processKafkaMessages :: Store alpha => Metrics -> KafkaConsumer -> U.InChan (Event alpha) -> IO ()
+processKafkaMessages met kc chan = forever $ do
+    threadDelay kafkaConnectDelayMs
+    msg <- pollMessage kc (Timeout 50)
+    either (\_ -> return ()) extractValue msg
+      where
+        extractValue m = maybe (print "kafka-error: crValue Nothing") writeRight (crValue m)
+        writeRight   v = either (\err -> print $ "decode-error: " ++ show err)
+                                (\x -> do
+                                    PC.inc (_ingressEvents met)
+                                        >> PC.add (B.length v) (_ingressBytes met)
+                                    U.writeChan chan x)
+                                (decode v)
+
+
+consumerProps :: KafkaConfig -> ConsumerProperties
+consumerProps conf =
+    KC.brokersList [BrokerAddress $ brokerAddress conf]
+         <> groupId (ConsumerGroupId . read $ conf ^. kafkaConGroup)
+         <> KC.logLevel KafkaLogInfo
+         <> KC.callbackPollMode CallbackPollModeSync
+
+
+consumerSub :: TopicName -> Subscription
+consumerSub topic = topics [topic]
+                    <> offsetReset Earliest
+
+
+brokerAddress :: KafkaConfig -> T.Text
+brokerAddress conf = T.pack $ (conf ^. kafkaConn . host) ++ ":" ++ (conf ^. kafkaConn . port)

--- a/src/Striot/Nodes/MQTT.hs
+++ b/src/Striot/Nodes/MQTT.hs
@@ -1,0 +1,79 @@
+module Striot.Nodes.MQTT
+( sendStreamMQTT
+, runMQTTSub
+) where
+
+import           Control.Concurrent.Chan.Unagi.Bounded    as U
+import           Control.DeepSeq                          (force)
+import qualified Control.Exception                        as E (evaluate)
+import           Control.Lens
+import qualified Data.ByteString                          as B (length)
+import qualified Data.ByteString.Lazy.Char8               as BLC
+import           Data.Store                               (Store, decode,
+                                                           encode)
+import           Network.MQTT.Client                      as MQTT hiding
+                                                                   (Timeout)
+import           Network.MQTT.Types                       (RetainHandling (..))
+import           Network.Socket                           (HostName,
+                                                           ServiceName)
+import           Network.URI                              (parseURI)
+import           Striot.FunctionalIoTtypes
+import           Striot.Nodes.Types                       as NT
+import           System.Metrics.Prometheus.Metric.Counter as PC (add, inc)
+import           System.Metrics.Prometheus.Metric.Gauge   as PG (dec, inc)
+
+
+sendStreamMQTT :: Store alpha => String -> NT.MQTTConfig -> Metrics -> Stream alpha -> IO ()
+sendStreamMQTT name conf met stream = do
+    mc <- runMQTTPub name (conf ^. mqttConn . host) (conf ^. mqttConn . port)
+    mapM_ (\x -> do
+                    val <- E.evaluate . force . encode $ x
+                    PC.inc (_egressEvents met)
+                        >> PC.add (B.length val) (_egressBytes met)
+                        >> publishq mc (read $ conf ^. mqttTopic) (BLC.fromStrict val) False QoS0 []) stream
+
+
+runMQTTPub :: String -> HostName -> ServiceName -> IO MQTTClient
+runMQTTPub name host port =
+    let (Just uri) = parseURI $ "mqtt://" ++ host ++ ":" ++ port
+    in  connectURI (netmqttConf name host port NoCallback) uri
+
+
+runMQTTSub :: Store alpha => String -> NT.MQTTConfig -> Metrics -> U.InChan (Event alpha) -> IO ()
+runMQTTSub name conf met chan = do
+    let h = conf ^. mqttConn . host
+        p = conf ^. mqttConn . port
+        (Just uri) = parseURI $ "mqtt://" ++ h ++ ":" ++ p
+    mc <- connectURI (netmqttConf name h p (SimpleCallback $ mqttMessageCallback met chan)) uri
+    print =<< subscribe mc (map (\x -> (x, subOptions)) [read $ (conf ^. mqttTopic)]) []
+    waitForClient mc
+
+
+mqttMessageCallback :: Store alpha => Metrics -> U.InChan (Event alpha) -> MQTTClient -> Topic -> BLC.ByteString -> [Property] -> IO ()
+mqttMessageCallback met chan mc topic msg _ =
+    let bmsg = BLC.toStrict msg
+    in  PC.inc (_ingressEvents met)
+            >> PC.add (B.length bmsg) (_ingressBytes met)
+            >> case decode bmsg of
+                    Right event -> U.writeChan chan event
+                    Left  _     -> return ()
+
+
+netmqttConf :: String -> HostName -> ServiceName -> MessageCallback -> MQTT.MQTTConfig
+netmqttConf name host port msgCB =
+    mqttConfig
+        { MQTT._hostname = host
+        , MQTT._port     = read port
+        , _connID        = name
+        , _username      = Just "striot"
+        , _password      = Just "striot"
+        , _msgCB         = msgCB }
+
+
+mqttSubOptions :: SubOptions
+mqttSubOptions =
+    subOptions
+        { _retainHandling    = SendOnSubscribeNew
+        , _retainAsPublished = True
+        , _noLocal           = True
+        , _subQoS            = QoS0 }

--- a/src/Striot/Nodes/MQTT.hs
+++ b/src/Striot/Nodes/MQTT.hs
@@ -11,6 +11,7 @@ import qualified Data.ByteString                          as B (length)
 import qualified Data.ByteString.Lazy.Char8               as BLC
 import           Data.Store                               (Store, decode,
                                                            encode)
+import           Data.Text                                as T (pack)
 import           Network.MQTT.Client                      as MQTT hiding
                                                                    (Timeout)
 import           Network.MQTT.Types                       (RetainHandling (..))
@@ -30,7 +31,7 @@ sendStreamMQTT name conf met stream = do
                     val <- E.evaluate . force . encode $ x
                     PC.inc (_egressEvents met)
                         >> PC.add (B.length val) (_egressBytes met)
-                        >> publishq mc (read $ conf ^. mqttTopic) (BLC.fromStrict val) False QoS0 []) stream
+                        >> publishq mc (T.pack $ conf ^. mqttTopic) (BLC.fromStrict val) False QoS0 []) stream
 
 
 runMQTTPub :: String -> HostName -> ServiceName -> IO MQTTClient
@@ -45,7 +46,7 @@ runMQTTSub name conf met chan = do
         p = conf ^. mqttConn . port
         (Just uri) = parseURI $ "mqtt://" ++ h ++ ":" ++ p
     mc <- connectURI (netmqttConf name h p (SimpleCallback $ mqttMessageCallback met chan)) uri
-    print =<< subscribe mc (map (\x -> (x, subOptions)) [read $ (conf ^. mqttTopic)]) []
+    print =<< subscribe mc (map (\x -> (x, subOptions)) [T.pack (conf ^. mqttTopic)]) []
     waitForClient mc
 
 

--- a/src/Striot/Nodes/TCP.hs
+++ b/src/Striot/Nodes/TCP.hs
@@ -1,0 +1,156 @@
+module Striot.Nodes.TCP
+( connectTCP
+, sendStreamTCP
+, processSocket
+) where
+
+import           Control.Concurrent                       (forkFinally)
+import           Control.Concurrent.Async                 (async)
+import           Control.Concurrent.Chan.Unagi.Bounded    as U
+import qualified Control.Exception                        as E (bracket, catch,
+                                                                evaluate)
+import           Control.Lens
+import           Control.Monad                            (forever)
+import qualified Data.ByteString                          as B (ByteString,
+                                                                length, null)
+import           Data.Store                               (Store, decode,
+                                                           encode)
+import qualified Data.Store.Streaming                     as SS
+import           Network.Socket
+import           Network.Socket.ByteString
+import           Striot.FunctionalIoTtypes
+import           Striot.Nodes.Types
+import           System.IO.ByteBuffer                     as BB
+import           System.Metrics.Prometheus.Metric.Counter as PC (add, inc)
+import           System.Metrics.Prometheus.Metric.Gauge   as PG (dec, inc)
+
+
+processSocket :: Store alpha => String -> TCPConfig -> Metrics -> IO (Stream alpha)
+processSocket name conf met = U.getChanContents =<< acceptConnections name conf met
+
+
+acceptConnections :: Store alpha => String -> TCPConfig -> Metrics -> IO (U.OutChan (Event alpha))
+acceptConnections name conf met = do
+    (inChan, outChan) <- U.newChan defaultChanSize
+    async $ connectTCP name conf met inChan
+    return outChan
+
+
+defaultChanSize :: Int
+defaultChanSize = 10
+
+
+{- connectTCP sits accepting any new connections. Once accepted, a new
+thread is forked to read from the socket. The function then loops to accept any
+subsequent connections -}
+connectTCP :: Store alpha
+           => String
+           -> TCPConfig
+           -> Metrics
+           -> U.InChan (Event alpha)
+           -> IO ()
+connectTCP _ conf met chan = do
+    sock <- listenSocket $ conf ^. tcpConn . port
+    forever $ do
+        (conn, _) <- accept sock
+        forkFinally (PG.inc (_ingressConn met)
+                    >> processData met conn chan)
+                    (\_ -> PG.dec (_ingressConn met)
+                        >> close conn)
+
+
+{- processData takes a Socket and UChan. All of the events are read through
+use of a ByteBuffer and recv. The events are decoded by using store-streaming
+and added to the chan  -}
+processData :: Store alpha => Metrics -> Socket -> U.InChan (Event alpha) -> IO ()
+processData met conn eventChan =
+    BB.with Nothing $ \buffer -> forever $ do
+        event <- decodeMessageBS' met buffer (readFromSocket conn)
+        case event of
+            Just m  -> do
+                        PC.inc (_ingressEvents met)
+                        U.writeChan eventChan $ SS.fromMessage m
+            Nothing -> print "decode failed"
+
+
+{- This is a rewrite of Data.Store.Streaming decodeMessageBS, passing in
+Metrics so that we can calculate ingressBytes while decoding -}
+decodeMessageBS' :: Store a
+                 => Metrics -> BB.ByteBuffer
+                 -> IO (Maybe B.ByteString) -> IO (Maybe (SS.Message a))
+decodeMessageBS' met = SS.decodeMessage (\bb _ bs -> PC.add (B.length bs)
+                                                            (_ingressBytes met)
+                                                     >> BB.copyByteString bb bs)
+
+
+{- Read up to 4096 bytes from the socket at a time, packing into a Maybe
+structure. As we use TCP sockets recv should block, and so if msg is empty
+the connection has been closed -}
+readFromSocket :: Socket -> IO (Maybe B.ByteString)
+readFromSocket conn = do
+    msg <- recv conn 4096
+    if B.null msg
+        then error "Upstream connection closed"
+        else return $ Just msg
+
+
+{- Connects to socket within a bracket to ensure the socket is closed if an
+exception occurs -}
+sendStreamTCP :: Store alpha => String -> TCPConfig -> Metrics -> Stream alpha -> IO ()
+sendStreamTCP _ _    _   []     = return ()
+sendStreamTCP _ conf met stream =
+    E.bracket (PG.inc (_egressConn met)
+               >> connectSocket (conf ^. tcpConn . host) (conf ^. tcpConn . port))
+              (\conn -> PG.dec (_egressConn met)
+                        >> close conn)
+              (\conn -> writeSocket conn met stream)
+
+
+{- Encode messages and send over the socket -}
+writeSocket :: Store alpha => Socket -> Metrics -> Stream alpha -> IO ()
+writeSocket conn met =
+    mapM_ (\event ->
+            let val = SS.encodeMessage . SS.Message $ event
+            in  PC.inc (_egressEvents met)
+                >> PC.add (B.length val) (_egressBytes met)
+                >> sendAll conn val)
+
+
+--- SOCKETS ---
+
+listenSocket :: ServiceName -> IO Socket
+listenSocket port = do
+    let hints = defaultHints { addrFlags = [AI_PASSIVE],
+                               addrSocketType = Stream }
+    (sock, addr) <- createSocket [] port hints
+    setSocketOption sock ReuseAddr 1
+    bind sock $ addrAddress addr
+    listen sock maxQConn
+    return sock
+    where maxQConn = 10
+
+
+connectSocket :: HostName -> ServiceName -> IO Socket
+connectSocket host port = do
+    let hints = defaultHints { addrSocketType = Stream }
+    (sock, addr) <- createSocket host port hints
+    setSocketOption sock KeepAlive 1
+    connect sock $ addrAddress addr
+    return sock
+
+
+createSocket :: HostName -> ServiceName -> AddrInfo -> IO (Socket, AddrInfo)
+createSocket host port hints = do
+    addr <- resolve host port hints
+    sock <- getSocket addr
+    return (sock, addr)
+  where
+    resolve host' port' hints' = do
+        addr:_ <- getAddrInfo (Just hints') (isHost host') (Just port')
+        return addr
+    getSocket addr = socket (addrFamily addr)
+                            (addrSocketType addr)
+                            (addrProtocol addr)
+    isHost h
+        | null h    = Nothing
+        | otherwise = Just h

--- a/src/Striot/Nodes/Types.hs
+++ b/src/Striot/Nodes/Types.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+
+module Striot.Nodes.Types where
+
+import Data.IORef
+import Control.Monad.Reader
+import Control.Lens.Combinators (makeClassy)
+import Control.Lens.TH
+import System.Metrics.Prometheus.Metric.Gauge   (Gauge)
+import System.Metrics.Prometheus.Metric.Counter (Counter)
+import Network.Socket (ServiceName, HostName)
+-- import Network.Mqtt.Topic ()
+
+
+data Metrics = Metrics
+    { _ingressConn   :: Gauge
+    , _ingressBytes  :: Counter
+    , _ingressEvents :: Counter
+    , _egressConn    :: Gauge
+    , _egressBytes   :: Counter
+    , _egressEvents  :: Counter
+    }
+
+data NetConfig = NetConfig
+    { _host :: HostName
+    , _port :: ServiceName
+    }
+makeLenses ''NetConfig
+
+data TCPConfig = TCPConfig
+    { _tcpConn :: NetConfig
+    }
+makeLenses ''TCPConfig
+
+data KafkaConfig = KafkaConfig
+    { _kafkaConn     :: NetConfig
+    , _kafkaTopic    :: String
+    , _kafkaConGroup :: String
+    }
+makeLenses ''KafkaConfig
+
+data MQTTConfig = MQTTConfig
+    { _mqttConn  :: NetConfig
+    , _mqttTopic :: String
+    }
+makeLenses ''MQTTConfig
+ 
+data ConnectionConfig = ConnTCPConfig TCPConfig
+                      | ConnKafkaConfig KafkaConfig
+                      | ConnMQTTConfig MQTTConfig
+
+data StriotConfig = StriotConfig
+    { _nodeName          :: String
+    , _ingressConnConfig :: ConnectionConfig
+    , _egressConnConfig  :: ConnectionConfig
+    , _met               :: IORef Metrics
+    , _chanSize          :: Int
+    }
+makeClassy ''StriotConfig
+
+newtype StriotApp a =
+    StriotApp {
+        unApp :: ReaderT StriotConfig IO a
+    } deriving (
+        Functor,
+        Applicative,
+        Monad,
+        MonadReader StriotConfig,
+        MonadIO
+    )

--- a/src/Striot/Nodes/Types.hs
+++ b/src/Striot/Nodes/Types.hs
@@ -65,8 +65,8 @@ makeClassy ''StriotConfig
 instance ToEnv StriotConfig where
     toEnv StriotConfig {..} =
         makeEnv $
-            [ "STRIOT_NODE_NAME"          .= _nodeName
-            , "STRIOT_CHAN_SIZE"          .= _chanSize
+            [ "STRIOT_NODE_NAME" .= _nodeName
+            , "STRIOT_CHAN_SIZE" .= _chanSize
             ] ++ writeConf INGRESS _ingressConnConfig
               ++ writeConf EGRESS  _egressConnConfig
 

--- a/src/Striot/Nodes/Types.hs
+++ b/src/Striot/Nodes/Types.hs
@@ -95,7 +95,7 @@ instance FromEnv StriotConfig where
             <$> envMaybe "STRIOT_NODE_NAME" .!= "striot"
             <*> readConf INGRESS
             <*> readConf EGRESS
-            <*> env "STRIOT_CHAN_SIZE"
+            <*> envMaybe "STRIOT_CHAN_SIZE" .!= 10
 
 readConf :: ConnectType -> Parser ConnectionConfig
 readConf t = do

--- a/src/Striot/Nodes/Types.hs
+++ b/src/Striot/Nodes/Types.hs
@@ -1,16 +1,19 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE TemplateHaskell            #-}
 
 module Striot.Nodes.Types where
 
-import Data.IORef
-import Control.Monad.Reader
-import Control.Lens.Combinators (makeClassy)
-import Control.Lens.TH
-import System.Metrics.Prometheus.Metric.Gauge   (Gauge)
-import System.Metrics.Prometheus.Metric.Counter (Counter)
-import Network.Socket (ServiceName, HostName)
--- import Network.Mqtt.Topic ()
+import           Control.Lens                             ((^.))
+import           Control.Lens.Combinators                 (makeClassy)
+import           Control.Lens.TH
+import           Control.Monad.Reader
+import           Data.IORef
+import           Network.Socket                           (HostName,
+                                                           ServiceName)
+import           System.Envy
+import           System.Metrics.Prometheus.Metric.Counter (Counter)
+import           System.Metrics.Prometheus.Metric.Gauge   (Gauge)
 
 
 data Metrics = Metrics
@@ -25,39 +28,97 @@ data Metrics = Metrics
 data NetConfig = NetConfig
     { _host :: HostName
     , _port :: ServiceName
-    }
+    } deriving (Show)
 makeLenses ''NetConfig
 
 data TCPConfig = TCPConfig
     { _tcpConn :: NetConfig
-    }
+    } deriving (Show)
 makeLenses ''TCPConfig
 
 data KafkaConfig = KafkaConfig
     { _kafkaConn     :: NetConfig
     , _kafkaTopic    :: String
     , _kafkaConGroup :: String
-    }
+    } deriving (Show)
 makeLenses ''KafkaConfig
 
 data MQTTConfig = MQTTConfig
     { _mqttConn  :: NetConfig
     , _mqttTopic :: String
-    }
+    } deriving (Show)
 makeLenses ''MQTTConfig
- 
+
 data ConnectionConfig = ConnTCPConfig TCPConfig
                       | ConnKafkaConfig KafkaConfig
                       | ConnMQTTConfig MQTTConfig
+                      deriving (Show)
 
 data StriotConfig = StriotConfig
     { _nodeName          :: String
     , _ingressConnConfig :: ConnectionConfig
     , _egressConnConfig  :: ConnectionConfig
-    , _met               :: IORef Metrics
     , _chanSize          :: Int
-    }
+    } deriving (Show)
 makeClassy ''StriotConfig
+
+instance ToEnv StriotConfig where
+    toEnv StriotConfig {..} =
+        makeEnv $
+            [ "STRIOT_NODE_NAME"          .= _nodeName
+            , "STRIOT_CHAN_SIZE"          .= _chanSize
+            ] ++ writeConf INGRESS _ingressConnConfig
+              ++ writeConf EGRESS  _egressConnConfig
+
+writeConf :: ConnectType -> ConnectionConfig -> [EnvVar]
+writeConf t (ConnTCPConfig   conf) =
+    let base = "STRIOT_" ++ show t ++ "_"
+    in  [ (base ++ "TYPE") .= "TCP"
+        , (base ++ "HOST") .= (conf ^. tcpConn . host)
+        , (base ++ "PORT") .= (conf ^. tcpConn . port)]
+writeConf t (ConnKafkaConfig conf) =
+    let base = "STRIOT_" ++ show t ++ "_"
+    in  [ (base ++ "TYPE")            .= "KAFKA"
+        , (base ++ "HOST")            .= (conf ^. kafkaConn . host)
+        , (base ++ "PORT")            .= (conf ^. kafkaConn . port)
+        , (base ++ "KAFKA_TOPIC")     .= (conf ^. kafkaTopic)
+        , (base ++ "KAFKA_CON_GROUP") .= (conf ^. kafkaConGroup)]
+writeConf t (ConnMQTTConfig  conf) =
+    let base = "STRIOT_" ++ show t ++ "_"
+    in  [ (base ++ "TYPE")       .= "MQTT"
+        , (base ++ "HOST")       .= (conf ^. mqttConn . host)
+        , (base ++ "PORT")       .= (conf ^. mqttConn . port)
+        , (base ++ "MQTT_TOPIC") .= (conf ^. mqttTopic)]
+
+instance FromEnv StriotConfig where
+    fromEnv _ = StriotConfig
+            <$> envMaybe "STRIOT_NODE_NAME" .!= "striot"
+            <*> readConf INGRESS
+            <*> readConf EGRESS
+            <*> env "STRIOT_CHAN_SIZE"
+
+readConf :: ConnectType -> Parser ConnectionConfig
+readConf t = do
+    let base = "STRIOT_" ++ show t ++ "_"
+    p <- env (base ++ "TYPE")
+    case p of
+        "TCP"   -> ConnTCPConfig
+                    <$> (TCPConfig
+                            <$> nc base)
+        "KAFKA" -> ConnKafkaConfig
+                    <$> (KafkaConfig
+                        <$> nc base
+                        <*> env (base ++ "KAFKA_TOPIC")
+                        <*> env (base ++ "KAFKA_CON_GROUP"))
+        "MQTT"  -> ConnMQTTConfig
+                    <$> (MQTTConfig
+                        <$> nc base
+                        <*> env (base ++ "MQTT_TOPIC"))
+
+nc :: String -> Parser NetConfig
+nc base = NetConfig
+        <$> env (base ++ "HOST")
+        <*> env (base ++ "PORT")
 
 newtype StriotApp a =
     StriotApp {
@@ -69,3 +130,11 @@ newtype StriotApp a =
         MonadReader StriotConfig,
         MonadIO
     )
+
+data ConnectType = INGRESS
+                 | EGRESS
+                 deriving (Show)
+
+data ConnectProtocol = TCP
+                     | KAFKA
+                     | MQTT

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,3 +11,4 @@ extra-deps:
 - connection-0.3.1
 - socks-0.6.1
 - hw-kafka-client-3.0.0
+- envy-2.0.0.0

--- a/striot.cabal
+++ b/striot.cabal
@@ -46,13 +46,12 @@ library
                     , net-mqtt          >= 0.6.2.1
                     , text
                     , process
-                    , stm
                     , deepseq
-                    , network-uri
-                    , hw-kafka-client   >= 3.0.0
-                    , mtl
-                    , lens
-                    , envy
+                    , network-uri       >= 2.6.1.0
+                    , hw-kafka-client   >= 3.0.0 
+                    , mtl               >= 2.2.2
+                    , lens              >= 4.17.1
+                    , envy              >= 2.0.0.0
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -78,13 +77,12 @@ test-suite test-striot
                     , net-mqtt          >= 0.6.2.1
                     , text
                     , process
-                    , stm
                     , deepseq
-                    , network-uri
+                    , network-uri       >= 2.6.1.0
                     , hw-kafka-client   >= 3.0.0
-                    , mtl
-                    , lens
-                    , envy
+                    , mtl               >= 2.2.2
+                    , lens              >= 4.17.1
+                    , envy              >= 2.0.0.0
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing

--- a/striot.cabal
+++ b/striot.cabal
@@ -20,6 +20,7 @@ library
                       Striot.FunctionalProcessing
                       Striot.LogicalOptimiser
                       Striot.Nodes
+                      Striot.Nodes.Types
                       Striot.CompileIoT
                       Striot.StreamGraph
   -- other-modules:
@@ -46,6 +47,8 @@ library
                     , deepseq
                     , network-uri
                     , hw-kafka-client   >= 3.0.0
+                    , mtl
+                    , lens
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -75,11 +78,14 @@ test-suite test-striot
                     , deepseq
                     , network-uri
                     , hw-kafka-client   >= 3.0.0
+                    , mtl
+                    , lens
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing
                       Striot.LogicalOptimiser
                       Striot.Nodes
+                      Striot.Nodes.Types
                       Striot.StreamGraph
                       VizGraph
   default-language:   Haskell2010

--- a/striot.cabal
+++ b/striot.cabal
@@ -21,6 +21,9 @@ library
                       Striot.LogicalOptimiser
                       Striot.Nodes
                       Striot.Nodes.Types
+                      Striot.Nodes.TCP
+                      Striot.Nodes.Kafka
+                      Striot.Nodes.MQTT
                       Striot.CompileIoT
                       Striot.StreamGraph
   -- other-modules:
@@ -49,6 +52,7 @@ library
                     , hw-kafka-client   >= 3.0.0
                     , mtl
                     , lens
+                    , envy
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -80,12 +84,16 @@ test-suite test-striot
                     , hw-kafka-client   >= 3.0.0
                     , mtl
                     , lens
+                    , envy
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing
                       Striot.LogicalOptimiser
                       Striot.Nodes
                       Striot.Nodes.Types
+                      Striot.Nodes.TCP
+                      Striot.Nodes.Kafka
+                      Striot.Nodes.MQTT
                       Striot.StreamGraph
                       VizGraph
   default-language:   Haskell2010


### PR DESCRIPTION
With the addition of new transport protocol functions from #72 we end up with very bespoke `nodeX` functions for different parts of a pipeline. This becomes a little confusing to use, and adds difficulty to automating the creation of different nodes. This PR aims to fix this by providing the following:

- A new `Striot.Nodes.Types` file introducing `StriotConfig`
- Updated `node(Source|Link|Sink)` functions which accept this configuration
- Dispatch functions to call the correct ingress/egress function based on config
- Helper functions to create `StriotConfig` in the same way as our original TCP-based functions (`defaultSource`, `defaultLink`, `defaultSink`)
- Instances of `ToEnv` and `FromEnv` to allow us to read the config from environment variables
- Separation of TCP/Kafka/MQTT code from the main `Nodes` module to separate imports and increase clarity of `Nodes`

There are some open issues that I am interested in discussing:

1. For Source and Sink, ingress and egress config are not required respectively - I currently set this to an unused `ConnectionConfig`, but I believe they should be `Maybe ConnectionConfig` and some logic should be changed
2. The `_kafkaConGroup` variable is only required for Consumers, when the ingress is `KAFKA` type. This should Maybe be present to fix this issue
3. The `nodeLink2` and `nodeSink2` functions require multiple ingress configurations - I thought about changing the configuration to a `[ConnectionConfig]`, but the logic changes quite drastically - and parsing an arbitrary sized list from the environment is not straightforward. For the time being I have left legacy-style code for these bespoke functions

The first two of these require a few logic changes, in particular the parser becomes less generalised, but shouldn't be too much work.

The environment variables are the following:

```
STRIOT_NODE_NAME - This is used for everything that requires a unique name (prometheus, MQTT, Kafka) (default: striot)
STRIOT_(INGRESS|EGRESS)_TYPE - Connection type, current options (TCP|KAFKA|MQTT)
STRIOT_(INGRESS|EGRESS)_HOST - Used by all three types
STRIOT_(INGRESS|EGRESS)_PORT - Used by all three types
STRIOT_(INGRESS|EGRESS)_KAFKA_TOPIC - KAFKA-only: topic name to produce/consume
STRIOT_(INGRESS|EGRESS)_KAFKA_CON_GROUP - KAFKA-only: consumer group to consume from (only used as INGRESS)
STRIOT_(INGRESS|EGRESS)_MQTT_TOPIC - MQTT-only: topic name to produce/consume
STRIOT_CHAN_SIZE - The size of the internal buffer - can modify based on memory constraints / event size / expected processing time (default: 10)
```

The `pipeline-kafka` and `pipeline-mqtt` examples have been updated to use these variables.