### PR TITLE
Fix tests post streamtype split

### DIFF
--- a/examples/expand/Makefile
+++ b/examples/expand/Makefile
@@ -5,7 +5,7 @@ node1 node2 node1/node.hs node2/node.hs: generate
 	./generate
 
 generate: generate.hs
-	ghc generate -i../../src
+	stack ghc -- -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o node1/node.hs node2/node.hs\

--- a/examples/expand/generate.hs
+++ b/examples/expand/generate.hs
@@ -1,4 +1,6 @@
 import Striot.CompileIoT
+import Striot.StreamGraph
+
 import Algebra.Graph
 
 opts = GenerateOpts { imports = [ "Striot.FunctionalIoTtypes"
@@ -10,6 +12,7 @@ opts = GenerateOpts { imports = [ "Striot.FunctionalIoTtypes"
                                 ]
                     , packages  = ["random"]
                     , preSource = Nothing
+                    , rewrite = False
                     }
 
 -- 40 words picked randomly from the dictionary, 20 of which are prefixed

--- a/examples/filter/Makefile
+++ b/examples/filter/Makefile
@@ -5,7 +5,7 @@ node1/node.hs node2/node.hs: generate
 	./generate
 
 generate: generate.hs
-	ghc generate -i../../src
+	stack ghc -- -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o node1/node.hs node2/node.hs \

--- a/examples/filter/generate.hs
+++ b/examples/filter/generate.hs
@@ -3,11 +3,13 @@
  -}
 
 import Striot.CompileIoT
+import Striot.StreamGraph
 import Algebra.Graph
 
 opts = GenerateOpts { imports   = ["Striot.FunctionalIoTtypes", "Striot.FunctionalProcessing", "Striot.Nodes", "Control.Concurrent", "System.Random"]
                     , packages  = ["random"]
                     , preSource = Nothing
+                    , rewrite = False
                     }
 
 source = "do\n\

--- a/examples/filterAcc/Makefile
+++ b/examples/filterAcc/Makefile
@@ -5,7 +5,7 @@ node1/node.hs node2/node.hs: generate
 	./generate
 
 generate: generate.hs
-	ghc generate -i../../src
+	stack ghc -- -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o node1/node.hs node2/node.hs \

--- a/examples/filterAcc/generate.hs
+++ b/examples/filterAcc/generate.hs
@@ -3,10 +3,12 @@
  -}
 
 import Striot.CompileIoT
+import Striot.StreamGraph
 import Algebra.Graph
 
 opts = defaultOpts { imports  = imports defaultOpts ++ ["System.Random"]
                    , packages = ["random"]
+                   , rewrite = False
                    }
 
 source = "do\n\

--- a/examples/join/Makefile
+++ b/examples/join/Makefile
@@ -7,7 +7,7 @@ node1 node2 node3 node1/node.hs node2/node.hs node3/node.hs: generate
 	./generate
 
 generate: generate.hs
-	ghc generate -i../../src
+	stack ghc -- -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o \

--- a/examples/join/generate.hs
+++ b/examples/join/generate.hs
@@ -1,4 +1,5 @@
 import Striot.CompileIoT
+import Striot.StreamGraph
 import Algebra.Graph
 
 source x = "do\n\

--- a/examples/merge/Makefile
+++ b/examples/merge/Makefile
@@ -7,7 +7,7 @@ node1 node2 node3 node1/node.hs node2/node.hs node3/node.hs: generate
 	./generate
 
 generate: generate.hs
-	ghc generate -i../../src
+	stack ghc -- -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o \

--- a/examples/merge/generate.hs
+++ b/examples/merge/generate.hs
@@ -3,6 +3,7 @@
  -}
 
 import Striot.CompileIoT
+import Striot.StreamGraph
 import Algebra.Graph
 
 source x = "do\n\

--- a/examples/pipeline/Makefile
+++ b/examples/pipeline/Makefile
@@ -7,7 +7,7 @@ node1 node2 node3 node1/node.hs node2/node.hs node3/node.hs: generate
 	./generate
 
 generate: generate.hs
-	ghc generate -i../../src
+	stack ghc -- -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o \

--- a/examples/pipeline/generate.hs
+++ b/examples/pipeline/generate.hs
@@ -3,6 +3,7 @@
  -}
 
 import Striot.CompileIoT
+import Striot.StreamGraph
 import Algebra.Graph
 
 graph = path

--- a/examples/scan/Makefile
+++ b/examples/scan/Makefile
@@ -5,7 +5,7 @@ node1/node.hs node2/node.hs: generate
 	./generate
 
 generate: generate.hs
-	ghc generate -i../../src
+	stack ghc -- -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o node1/node.hs node2/node.hs \

--- a/examples/scan/generate.hs
+++ b/examples/scan/generate.hs
@@ -1,4 +1,5 @@
 import Striot.CompileIoT
+import Striot.StreamGraph
 import Algebra.Graph
 
 source x = "do\n\

--- a/examples/taxi/Makefile
+++ b/examples/taxi/Makefile
@@ -19,7 +19,7 @@ node2 node3 node1/node.hs node2/node.hs node3/node.hs: generate
 	./generate
 
 generate: generate.hs
-	ghc generate -i../../src
+	stack ghc -- -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o \

--- a/gen_test_makefile.sh
+++ b/gen_test_makefile.sh
@@ -28,7 +28,7 @@ gen()
         echo -e "\tcd \"$d\" && ./generate"
 
         for n in "$d"/node?/node.hs
-            do echo -e "\tghc -i. $n"
+            do echo -e "\tstack ghc -- -i. -i$d $n"
         done
         echo
     done


### PR DESCRIPTION
These are the necessary (and optional) changes needed to run all the tests subsequent to merging  f59d88d37b52a85fec72756d8a52e8a21d0f2b74 (and possibly others)