### PR TITLE
Small Make/clean improvements and tidy-ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ cabal.sandbox.config
 *.eventlog
 .stack-work/
 cabal.project.local
-
+/tags

--- a/examples/pipeline/Makefile
+++ b/examples/pipeline/Makefile
@@ -12,6 +12,8 @@ generate: generate.hs
 clean:
 	rm -f generate generate.hi generate.o \
 	    node1/node.hs node2/node.hs node3/node.hs \
+	    node1/node.hi node2/node.hi node3/node.hi \
+	    node1/node.o node2/node.o node3/node.o \
 	    node1/node node2/node node3/node \
 	    node1/Dockerfile node2/Dockerfile node3/Dockerfile
 	-rmdir node1 node2 node3

--- a/examples/simplest/Makefile
+++ b/examples/simplest/Makefile
@@ -1,2 +1,7 @@
 run:
 	docker-compose up --build
+
+clean:
+	rm -f client/Client server/Server
+
+.PHONY: run clean

--- a/examples/taxi/Makefile
+++ b/examples/taxi/Makefile
@@ -26,6 +26,7 @@ clean:
 	    Taxi.hi Taxi.o \
 	    node1/node.hs node2/node.hs node3/node.hs \
 	    node1/node.hi node2/node.hi node3/node.hi \
+	    node1/node node2/node node3/node \
 	    node1/node.o node2/node.o node3/node.o \
 	    node1/Taxi.hs node2/Taxi.hs node3/Taxi.hs \
 	    node1/Dockerfile node2/Dockerfile node3/Dockerfile

--- a/examples/taxi/Makefile
+++ b/examples/taxi/Makefile
@@ -4,7 +4,7 @@ run: nodes
 gen: generate
 	./generate
 
-nodes: node1/node.hs node2/node.hs node3/node.hs node1/Taxi.hs node2/Taxi.hs node3/Taxi.hs
+nodes: node1/node.hs node2/node.hs node3/node.hs node1/Taxi.hs node2/Taxi.hs node3/Taxi.hs node1/sorteddata.csv
 
 node1/Taxi.hs: Taxi.hs
 	cp Taxi.hs node1
@@ -21,16 +21,23 @@ node2 node3 node1/node.hs node2/node.hs node3/node.hs: generate
 generate: generate.hs
 	stack ghc -- -i../../src generate.hs
 
+# This file is deliberately left out of the "clean" target.
+sorteddata.csv.xz:
+	curl https://www.staff.ncl.ac.uk/jon.dowland/phd/debs2015/sorteddata.csv.xz >$@
+
+node1/sorteddata.csv: sorteddata.csv.xz
+	xzcat $< >$@
+
 clean:
 	rm -f generate generate.hi generate.o \
 	    Taxi.hi Taxi.o \
+	    node1/sorteddata.csv \
 	    node1/node.hs node2/node.hs node3/node.hs \
 	    node1/node.hi node2/node.hi node3/node.hi \
 	    node1/node node2/node node3/node \
 	    node1/node.o node2/node.o node3/node.o \
 	    node1/Taxi.hs node2/Taxi.hs node3/Taxi.hs \
 	    node1/Dockerfile node2/Dockerfile node3/Dockerfile
-	-test ! -d node2 || rmdir node2
-	-test ! -d node3 || rmdir node3
+	-rmdir node1 node2 node3
 
 .PHONY: clean nodes gen

--- a/gen_test_makefile.sh
+++ b/gen_test_makefile.sh
@@ -6,8 +6,12 @@ shopt -s nullglob
 # Generates a Makefile with a default target that performs the following steps
 # for every applicable example under examples/:
 #
-#   • build and run "generate" (clean first to ensure it's regenerated)
-#   • build any node?/node.hs files output by "generate"
+#  1. build and run "generate" (clean first to ensure it's regenerated)
+#  2. build any node?/node.hs files output by "generate"
+#
+# In a clean checkout, this script needs to be run *twice*: the first Makefile
+# to generate all the individual nodes, and the second run to generate rules 
+# to build all of them.
 #
 # This can be used as a brute-force method of ensuring that the above all
 # typecheck and compile properly when making structural changes to the Striot


### PR DESCRIPTION
A grab bag of small tidy-ups I made when cleaning up my local checkout.

I'd like to use Travis CI a bit more: in particular, I'd like every PR to execute `./gen_test_makefile.sh > Makefile; make; ./gen_test_makefile.sh > Makefile; make` and to build and run `TestMain`. These are some baby steps towards that.