### PR TITLE
Travis make examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ stages:
     if: branch = master AND type = push
 
 before_install:
+  # install librdkafka-dev
   - wget -qO - https://packages.confluent.io/deb/5.3/archive.key | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/5.3 stable main"
   - sudo apt-get update && sudo apt-get install librdkafka-dev
@@ -26,6 +27,10 @@ jobs:
   include:
     - stage: build
       name: Build and test striot
+      script:
+        - cabal configure --enable-tests && cabal build && cabal test
+        - ./gen_test_makefile.sh > Makefile
+        - make
     - stage: image
       install: true
       name: Build striot-base docker image

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ jobs:
       name: Build and test striot
       script:
         - cabal configure --enable-tests && cabal build && cabal test
-        - ./gen_test_makefile.sh > Makefile; make GHC=ghc
-        - ./gen_test_makefile.sh > Makefile; make GHC=ghc
+        - ./gen_test_makefile.sh > Makefile; make GHC="cabal exec ghc --"
+        - ./gen_test_makefile.sh > Makefile; make GHC="cabal exec ghc --"
     - stage: image
       install: true
       name: Build striot-base docker image

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ jobs:
       name: Build and test striot
       script:
         - cabal configure --enable-tests && cabal build && cabal test
-        - ./gen_test_makefile.sh > Makefile
-        - make
+        - ./gen_test_makefile.sh > Makefile; make GHC=ghc
+        - ./gen_test_makefile.sh > Makefile; make GHC=ghc
     - stage: image
       install: true
       name: Build striot-base docker image


### PR DESCRIPTION
Resolves #81 

Moved `image` into `deploy` block with `skip_cleanup` in the hopes that we do not need to build the library twice for each stage. If this works it should half travis build time for merges to master - will have to check whether this works after merge.