### PR TITLE
Parameterize ghc in Makefiles

### DIFF
--- a/examples/expand/Makefile
+++ b/examples/expand/Makefile
@@ -1,3 +1,5 @@
+GHC := stack ghc --
+
 run: node1/node.hs node2/node.hs
 	docker-compose up --build
 
@@ -5,7 +7,7 @@ node1 node2 node1/node.hs node2/node.hs: generate
 	./generate
 
 generate: generate.hs
-	stack ghc -- -i../../src generate.hs
+	$(GHC) -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o node1/node.hs node2/node.hs\

--- a/examples/filter/Makefile
+++ b/examples/filter/Makefile
@@ -1,3 +1,5 @@
+GHC := stack ghc --
+
 run: node1/node.hs node2/node.hs
 	docker-compose up --build
 
@@ -5,7 +7,7 @@ node1/node.hs node2/node.hs: generate
 	./generate
 
 generate: generate.hs
-	stack ghc -- -i../../src generate.hs
+	$(GHC) -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o node1/node.hs node2/node.hs \

--- a/examples/filterAcc/Makefile
+++ b/examples/filterAcc/Makefile
@@ -1,3 +1,5 @@
+GHC := stack ghc --
+
 run: node1/node.hs node2/node.hs
 	docker-compose up --build
 
@@ -5,7 +7,7 @@ node1/node.hs node2/node.hs: generate
 	./generate
 
 generate: generate.hs
-	stack ghc -- -i../../src generate.hs
+	$(GHC) -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o node1/node.hs node2/node.hs \

--- a/examples/join/Makefile
+++ b/examples/join/Makefile
@@ -1,3 +1,5 @@
+GHC := stack ghc --
+
 run: nodes
 	docker-compose up --build
 
@@ -7,7 +9,7 @@ node1 node2 node3 node1/node.hs node2/node.hs node3/node.hs: generate
 	./generate
 
 generate: generate.hs
-	stack ghc -- -i../../src generate.hs
+	$(GHC) -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o \

--- a/examples/merge/Makefile
+++ b/examples/merge/Makefile
@@ -1,3 +1,5 @@
+GHC := stack ghc --
+
 run: nodes
 	docker-compose up --build
 
@@ -7,7 +9,7 @@ node1 node2 node3 node1/node.hs node2/node.hs node3/node.hs: generate
 	./generate
 
 generate: generate.hs
-	stack ghc -- -i../../src generate.hs
+	$(GHC) -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o \

--- a/examples/pipeline/Makefile
+++ b/examples/pipeline/Makefile
@@ -1,3 +1,5 @@
+GHC := stack ghc --
+
 run: nodes
 	docker-compose up --build
 
@@ -7,7 +9,7 @@ node1 node2 node3 node1/node.hs node2/node.hs node3/node.hs: generate
 	./generate
 
 generate: generate.hs
-	stack ghc -- -i../../src generate.hs
+	$(GHC) -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o \

--- a/examples/scan/Makefile
+++ b/examples/scan/Makefile
@@ -1,3 +1,5 @@
+GHC := stack ghc --
+
 run: node1/node.hs node2/node.hs
 	docker-compose up --build
 
@@ -5,7 +7,7 @@ node1/node.hs node2/node.hs: generate
 	./generate
 
 generate: generate.hs
-	stack ghc -- -i../../src generate.hs
+	$(GHC) -i../../src generate.hs
 
 clean:
 	rm -f generate generate.hi generate.o node1/node.hs node2/node.hs \

--- a/examples/taxi/Makefile
+++ b/examples/taxi/Makefile
@@ -1,3 +1,5 @@
+GHC := stack ghc --
+
 run: nodes
 	docker-compose up --build
 
@@ -19,7 +21,7 @@ node2 node3 node1/node.hs node2/node.hs node3/node.hs: generate
 	./generate
 
 generate: generate.hs
-	stack ghc -- -i../../src generate.hs
+	$(GHC) -i../../src generate.hs
 
 # This file is deliberately left out of the "clean" target.
 sorteddata.csv.xz:

--- a/gen_test_makefile.sh
+++ b/gen_test_makefile.sh
@@ -28,8 +28,8 @@ gen()
         a+=("$d")
 
         echo -e "$d:"
-        echo -e "\tmake -C $d clean GHC=\"\$(GHC)\""
-        echo -e "\tmake -C $d generate GHC=\"\$(GHC)\""
+        echo -e "\t+make -C $d clean GHC=\"\$(GHC)\""
+        echo -e "\t+make -C $d generate GHC=\"\$(GHC)\""
         echo -e "\tcd \"$d\" && ./generate"
 
         for n in "$d"/node?/node.hs
@@ -40,7 +40,7 @@ gen()
 
     echo clean:
     for d in "${a[@]}"; do
-        echo -e "\tmake -C $d clean GHC=\"\$(GHC)\""
+        echo -e "\t+make -C $d clean GHC=\"\$(GHC)\""
     done
     echo
 

--- a/gen_test_makefile.sh
+++ b/gen_test_makefile.sh
@@ -33,7 +33,7 @@ gen()
         echo -e "\tcd \"$d\" && ./generate"
 
         for n in "$d"/node?/node.hs
-            do echo -e "\t\$(GHC) -i. -i$d $n"
+            do echo -e "\t\$(GHC) -isrc -i$d $n"
         done
         echo
     done

--- a/gen_test_makefile.sh
+++ b/gen_test_makefile.sh
@@ -20,6 +20,7 @@ shopt -s nullglob
 gen()
 {
     a=()
+    echo GHC := stack ghc --
     echo default: default2
     echo
     for m in examples/*/generate.hs; do
@@ -27,19 +28,19 @@ gen()
         a+=("$d")
 
         echo -e "$d:"
-        echo -e "\tmake -C $d clean"
-        echo -e "\tmake -C $d generate"
+        echo -e "\tmake -C $d clean GHC=\"\$(GHC)\""
+        echo -e "\tmake -C $d generate GHC=\"\$(GHC)\""
         echo -e "\tcd \"$d\" && ./generate"
 
         for n in "$d"/node?/node.hs
-            do echo -e "\tstack ghc -- -i. -i$d $n"
+            do echo -e "\t\$(GHC) -i. -i$d $n"
         done
         echo
     done
 
     echo clean:
     for d in "${a[@]}"; do
-        echo -e "\tmake -C $d clean"
+        echo -e "\tmake -C $d clean GHC=\"\$(GHC)\""
     done
     echo
 


### PR DESCRIPTION
Default to "stack ghc --", which is appropriate for users of Stack,
but permits us to override it for e.g. Travis to use plain old "ghc".
Other choices might include "cabal exec ghc", for users of Cabal
sandboxes.