### PR TITLE
Logical Operator first function

### DIFF
--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -299,12 +299,3 @@ simpleStream tupes = path lst
         tupes3 = zip3 [1..] intypes tupes
         lst = map (\ (i,intype,(op,params,outtype)) ->
             StreamVertex i op params intype outtype) tupes3
-
-------------------------------------------------------------------------------
--- logical optimisation
-
-optimise :: StreamGraph -> StreamGraph
-optimise sg = let
-    sgs  = applyRules 5 sg
-    best = snd $ maximum $ map (\g -> (costModel g, g) ) sgs
-    in best

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -226,7 +226,10 @@ generateCodeFromVertex (opid, v)  = let
         then ["n", show (opid-2), " n", show (opid-1)]
         else ["n", show (opid-1)]
     in
-        "n" ++ show opid ++ " = (\\" ++ lparams ++ " -> " ++ show op ++ " " ++ params ++ ") " ++ args
+        "n" ++ show opid ++ " = (\\" ++ lparams ++ " -> " ++ printOp op ++ " " ++ params ++ ") " ++ args
+
+printOp :: StreamOperator -> String
+printOp = (++) "stream" . show
 
 -- how many incoming edges to this partition?
 -- + how many source nodes

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -2,6 +2,7 @@
 
 module Striot.LogicalOptimiser ( applyRules
                                , costModel
+                               , optimise
 
                                , htf_thisModulesTests
                                ) where
@@ -48,6 +49,14 @@ applyRules n sg =
         else let
              sgs = map ((&) sg) $ mapMaybe (firstMatch sg) rules
              in    sg : sgs ++ (concatMap (applyRules (n-1)) sgs)
+
+-- | Return an optimised version of the supplied StreamGraph, or the
+-- graph itself if no better alternative is found.
+optimise :: StreamGraph -> StreamGraph
+optimise sg = let
+    sgs  = nub $ applyRules 5 sg
+    best = snd $ maximum $ map (\g -> (costModel g, g) ) sgs
+    in best
 
 rules :: [RewriteRule]
 rules = [ filterFuse
@@ -396,3 +405,4 @@ newVertexId :: StreamGraph -> Int
 newVertexId = succ . last . sort . map vertexId . vertexList
 
 main = htfMain htf_thisModulesTests
+

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -3,6 +3,7 @@
 module Striot.LogicalOptimiser ( applyRules
                                , costModel
                                , optimise
+                               , optimiseWriteOut
 
                                , htf_thisModulesTests
                                ) where
@@ -12,7 +13,7 @@ import Algebra.Graph
 import Test.Framework hiding ((===))
 import Data.Maybe (mapMaybe, fromMaybe)
 import Data.Function ((&))
-import Data.List (nub, sort)
+import Data.List (nub, sort, intercalate)
 
 -- applying encoded rules and their resulting ReWriteOps ----------------------
 
@@ -60,6 +61,22 @@ optimise sg = let
     in if score > base
        then candidate
        else sg
+
+-- | Optimise a StreamGraph and write the result out as Haskell source
+-- code to the supplied FilePath, along with some of the necessary
+-- supporting code.
+optimiseWriteOut :: FilePath -> StreamGraph -> IO ()
+optimiseWriteOut fn =
+    writeFile fn . template . show . simplify . optimise
+
+template g = intercalate "\n"
+    [ "import Striot.StreamGraph"
+    , "import Algebra.Graph"
+    , "\n"
+    , "graph = " ++ g
+    ]
+
+------------------------------------------------------------------------------
 
 rules :: [RewriteRule]
 rules = [ filterFuse
@@ -408,4 +425,3 @@ newVertexId :: StreamGraph -> Int
 newVertexId = succ . last . sort . map vertexId . vertexList
 
 main = htfMain htf_thisModulesTests
-

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -54,9 +54,12 @@ applyRules n sg =
 -- graph itself if no better alternative is found.
 optimise :: StreamGraph -> StreamGraph
 optimise sg = let
-    sgs  = nub $ applyRules 5 sg
-    best = snd $ maximum $ map (\g -> (costModel g, g) ) sgs
-    in best
+    base              = costModel sg
+    sgs               = nub $ applyRules 5 sg
+    (score,candidate) = maximum $ map (\g -> (costModel g, g) ) sgs
+    in if score > base
+       then candidate
+       else sg
 
 rules :: [RewriteRule]
 rules = [ filterFuse

--- a/src/Striot/StreamGraph.hs
+++ b/src/Striot/StreamGraph.hs
@@ -38,19 +38,7 @@ data StreamOperator = Map
                     | FilterAcc
                     | Source
                     | Sink
-                    deriving (Ord,Eq)
-
-instance Show StreamOperator where
-    show Map             = "streamMap"
-    show Filter          = "streamFilter"
-    show Window          = "streamWindow"
-    show Merge           = "streamMerge"
-    show Join            = "streamJoin"
-    show Scan            = "streamScan"
-    show FilterAcc       = "streamFilterAcc"
-    show Expand          = "streamExpand"
-    show Source          = "streamSource"
-    show Sink            = "streamSink"
+                    deriving (Show,Ord,Eq)
 
 instance Ord StreamVertex where
     compare x y = compare (vertexId x) (vertexId y)

--- a/src/Striot/VizGraph.hs
+++ b/src/Striot/VizGraph.hs
@@ -1,8 +1,8 @@
 {-# OPTIONS_GHC -F -pgmF htfpp #-}
 
-module VizGraph ( streamGraphToDot
-                , displayGraph
-                , htf_thisModulesTests) where
+module Striot.VizGraph ( streamGraphToDot
+                       , displayGraph
+                       , htf_thisModulesTests) where
 
 import Striot.StreamGraph
 import Algebra.Graph

--- a/src/Striot/VizGraph.hs
+++ b/src/Striot/VizGraph.hs
@@ -18,7 +18,10 @@ streamGraphToDot :: StreamGraph -> String
 streamGraphToDot = export myStyle
 
 show' :: StreamVertex -> String
-show' v = intercalate " " $ ((show . operator) v) : ((map (\s->"("++s++")")) . parameters) v
+show' v = intercalate " " $ ((printOp . operator) v) : ((map (\s->"("++s++")")) . parameters) v
+
+printOp :: StreamOperator -> String
+printOp = (++) "stream" . show
 
 myStyle :: Style StreamVertex String
 myStyle = Style

--- a/src/TestMain.hs
+++ b/src/TestMain.hs
@@ -4,7 +4,7 @@ module Main where
 
 import Test.Framework
 import {-@ HTF_TESTS @-} Striot.CompileIoT
-import {-@ HTF_TESTS @-} VizGraph
+import {-@ HTF_TESTS @-} Striot.VizGraph
 
 import Striot.FunctionalIoTtypes
 import {-@ HTF_TESTS @-} Striot.FunctionalProcessing

--- a/striot.cabal
+++ b/striot.cabal
@@ -22,6 +22,7 @@ library
                       Striot.Nodes
                       Striot.CompileIoT
                       Striot.StreamGraph
+                      Striot.VizGraph
   -- other-modules:
   -- other-extensions:
   build-depends:      base              >= 4.9
@@ -81,5 +82,5 @@ test-suite test-striot
                       Striot.LogicalOptimiser
                       Striot.Nodes
                       Striot.StreamGraph
-                      VizGraph
+                      Striot.VizGraph
   default-language:   Haskell2010


### PR DESCRIPTION
As discussed this morning. Add a function `optimiseWriteOut` to LogicalOptimiser which can be the initial entry point to StrIoT for a user. It takes a stream graph, and writes out a possibly-optimised stream graph to the supplied file-path. Phase 2 Would be a human checking that, adding a partition map and call to `partitionGraph` in order to generate the partitioned code for deployment/the Deployer.

`optimiseWriteOut` should probably be extended in future with something similar to `GenerateOpts`, i.e. a way of encapsulating options for the code generator, such as a list of `import` statements to include in the result, etc.

Then later on we can try auto-partitioning, extend the cost model, etc.