### PR TITLE
Implement (nearly all) the remaining rules from the draft paper

### DIFF
--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -98,6 +98,7 @@ rules = [ filterFuse
         , mergeExpand
         , mergeMap
         , mapMerge
+        , filterMerge
         ]
 
 -- streamFilter f >>> streamFilter g = streamFilter (\x -> f x && g x) -------
@@ -649,9 +650,41 @@ mapMerge (Connect (Vertex ma@(StreamVertex i Map fs t1 t2))
 mapMerge _ = Nothing
 
 mapMergePre  = mergeMapPost
-mapMergePost = overlay (path [v15,v17,v18 { vertexId = 7 }, v19]) (path [v16,v17])
+mapMergePost = overlay (path [v15,v17,v18 {vertexId = 7}, v19]) (path [v16,v17])
 
 test_mapMerge = assertEqual (applyRule mapMerge mapMergePre) mapMergePost
+
+-- streamMerge [streamFilter p s1, streamFilter p s2] ------------------------
+-- == streamFilter p (streamMerge [s1,s2])
+
+filterMerge :: RewriteRule
+filterMerge (Connect (Vertex f@(StreamVertex i Filter fs t1 t2))
+                  (Vertex me@(StreamVertex j Merge _ t3 _))) =
+    Just $ \g -> let
+        inbound = map fst . filter ((me==) . snd) . edgeList $ g
+        -- the pattern match is not enough to be conclusive that this applies
+        in  if [Filter] == nub (map operator inbound) &&
+            1 == length (nub (map parameters inbound))
+            then let
+                me' = me { intype = t1, outtype = t1 }
+                f' = f { vertexId =  newVertexId g }
+                on  = snd . head . filter ((==me) . fst) . edgeList $ g
+                in ( removeEdge me on
+                    -- remove all the inbound filters
+                    >>> mergeVertices (`elem` inbound) me
+                    >>> replaceVertex me me' -- fix Merge type
+                    >>> removeEdge me' me'
+                    -- new after Merge
+                    >>> overlay (path [me', f', on])
+                ) g
+           else g
+
+filterMerge _ = Nothing
+
+filterMergePre  = mergeFilterPost
+filterMergePost = overlay (path [v1,v3,v4 {vertexId=7},v5]) (path [v2,v3])
+test_filterMerge = assertEqual (applyRule filterMerge filterMergePre)
+    filterMergePost
 
 -- utility/boilerplate -------------------------------------------------------
 

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -95,6 +95,7 @@ rules = [ filterFuse
         , expandExpand
         , windowExpandWindow
         , mergeFilter 
+        , mergeExpand
         ]
 
 -- streamFilter f >>> streamFilter g = streamFilter (\x -> f x && g x) -------
@@ -574,6 +575,29 @@ mergeFilterPost = overlay (path [v1,v6,v3,v5]) (path [v2,v7,v3])
 
 test_mergeFilter = assertEqual (applyRule mergeFilter mergeFilterPre)
     mergeFilterPost
+
+-- streamExpand (streamMerge [s1, s2]) -------------------------------------
+-- = streamMerge [streamExpand s1, streamExpand s2]
+
+mergeExpand :: RewriteRule
+mergeExpand = hoistOp Expand
+
+v8  = StreamVertex 0 Source [] "[Int]" "[Int]"
+v9  = StreamVertex 1 Source [] "[Int]" "[Int]"
+v10 = StreamVertex 2 Merge  [] "[Int]" "[Int]"
+v11 = StreamVertex 3 Expand [] "[Int]" "Int"
+
+mergeExpandPre  = overlay (path [v8, v10, v11, v5]) (path [v9, v10])
+
+v12 = StreamVertex 2 Merge  [] "Int" "Int"
+v13 = StreamVertex 5 Expand [] "[Int]" "Int"
+v14 = StreamVertex 6 Expand [] "[Int]" "Int"
+
+mergeExpandPost = overlay (path [v8, v13, v12, v5]) (path [v9, v14, v12])
+
+test_mergeExpand = assertEqual (applyRule mergeExpand mergeExpandPre)
+    mergeExpandPost
+
 -- utility/boilerplate -------------------------------------------------------
 
 -- | left-biased rule application via fold

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -96,6 +96,7 @@ rules = [ filterFuse
         , windowExpandWindow
         , mergeFilter 
         , mergeExpand
+        , mergeMap
         ]
 
 -- streamFilter f >>> streamFilter g = streamFilter (\x -> f x && g x) -------
@@ -597,6 +598,28 @@ mergeExpandPost = overlay (path [v8, v13, v12, v5]) (path [v9, v14, v12])
 
 test_mergeExpand = assertEqual (applyRule mergeExpand mergeExpandPre)
     mergeExpandPost
+
+-- streamMap (streamMerge [s1, s2]) ------------------------------------------
+-- = streamMerge [streamMap s1, streamMap s2]
+
+mergeMap :: RewriteRule
+mergeMap = hoistOp Map
+
+v15 = StreamVertex 0 Source [] "Int" "Int"
+v16 = StreamVertex 1 Source [] "Int" "Int"
+v17 = StreamVertex 2 Merge []  "Int" "Int"
+v18 = StreamVertex 3 Map ["show","s"]  "Int" "String"
+v19 = StreamVertex 4 Sink [] "String" "String"
+
+mergeMapPre = overlay (path [v15,v17,v18,v19]) (path [v16,v17])
+
+v20 = StreamVertex 5 Map ["show","s"]  "Int" "String"
+v21 = StreamVertex 6 Map ["show","s"]  "Int" "String"
+v22 = StreamVertex 2 Merge [] "String" "String"
+
+mergeMapPost = overlay (path [v15,v20,v22,v19]) (path [v16,v21,v22])
+
+test_mergeMap = assertEqual (applyRule mergeMap mergeMapPre) mergeMapPost
 
 -- utility/boilerplate -------------------------------------------------------
 

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -99,6 +99,7 @@ rules = [ filterFuse
         , mergeMap
         , mapMerge
         , filterMerge
+        , expandMerge
         ]
 
 -- streamFilter f >>> streamFilter g = streamFilter (\x -> f x && g x) -------
@@ -669,6 +670,17 @@ filterMergePre  = mergeFilterPost
 filterMergePost = overlay (path [v1,v3,v4 {vertexId=7},v5]) (path [v2,v3])
 test_filterMerge = assertEqual (applyRule filterMerge filterMergePre)
     filterMergePost
+
+-- streamMerge [streamExpand s1, streamExpand s2] ----------------------------
+-- == streamExpand (streamMerge [s1,s2])
+
+expandMerge :: RewriteRule
+expandMerge = pushOp Expand
+
+expandMergePre  = mergeExpandPost
+expandMergePost = overlay (path [v8, v10, v11 {vertexId=7}, v5]) (path [v9, v10])
+test_expandMerge = assertEqual (applyRule expandMerge expandMergePre)
+    expandMergePost
 
 -- utility/boilerplate -------------------------------------------------------
 


### PR DESCRIPTION
Here are the vast majority of the rules from the draft paper, complete with at least one test per ruie.

I've also extended the existing tests to ensure that edges in and out of the matching part of a graph are rewritten properly.