### PR TITLE
multiple incoming partitions target the same TCP/IP port

### DIFF
--- a/examples/merge/docker-compose.yml
+++ b/examples/merge/docker-compose.yml
@@ -1,21 +1,29 @@
 # consumer via streamMerge
+node4:
+  build: node4
+  stdin_open: true
+  tty: true
+
+# producers:
+
 node3:
   build: node3
   stdin_open: true
   tty: true
+  links:
+    - node4
 
-# first producer
 node2:
   build: node2
   stdin_open: true
   tty: true
   links:
-    - node3
+    - node4
 
-# second producer
+
 node1:
   build: node1
   stdin_open: true
   tty: true
   links:
-    - node3
+    - node4

--- a/examples/merge/generate.hs
+++ b/examples/merge/generate.hs
@@ -6,21 +6,19 @@ import Striot.CompileIoT
 import Striot.StreamGraph
 import Algebra.Graph
 
-source x = "do\n\
-\    threadDelay (1000*1000)\n\
+source x y = "do\n\
+\    threadDelay ("++y++")\n\
 \    putStrLn \"sending '"++x++"'\"\n\
 \    return \""++x++"\""
 
+v1 = StreamVertex 1 Source [source "foo" "1000*1000"] "String" "String"
+v2 = StreamVertex 2 Source [source "bar"  "500*1000"] "String" "String"
+v3 = StreamVertex 3 Merge  ["[s1,s2]"]                "String" "String"
+-- XXX: ^ we lie about the input type here, because the generated function has split-out arguments
+v4 = StreamVertex 4 Sink   ["mapM_ print"] "String" "IO ()"
 
-v1 = StreamVertex 1 Source [source "foo"]  "String" "String"
-v2 = StreamVertex 2 Map    ["id", "s"]     "String" "String"
-v3 = StreamVertex 3 Source [source "bar"]  "String" "String"
-v4 = StreamVertex 4 Map    ["id", "s"]     "String" "String"
-v5 = StreamVertex 5 Merge  ["[s1,s2]"]     "String" "String" -- XXX: we lie about the input type here, because the generated function has split-out arguments
-v6 = StreamVertex 6 Sink   ["mapM_ print"] "String" "IO ()"
+graph = overlay (path [v1, v3]) $ path [v2, v3, v4]
 
-graph = overlay (path [v3, v4, v5]) $ path [v1, v2, v5, v6]
-
-parts = [[1,2],[3,4],[5,6]]
+parts = [[1],[2],[3,4]]
 
 main = partitionGraph graph parts defaultOpts

--- a/examples/merge/generate.hs
+++ b/examples/merge/generate.hs
@@ -13,12 +13,14 @@ source x y = "do\n\
 
 v1 = StreamVertex 1 Source [source "foo" "1000*1000"] "String" "String"
 v2 = StreamVertex 2 Source [source "bar"  "500*1000"] "String" "String"
-v3 = StreamVertex 3 Merge  ["[s1,s2]"]                "String" "String"
+v3 = StreamVertex 3 Source [source "baz"  "200*1000"] "String" "String"
+
+v4 = StreamVertex 4 Merge [] "String" "String"
 -- XXX: ^ we lie about the input type here, because the generated function has split-out arguments
-v4 = StreamVertex 4 Sink   ["mapM_ print"] "String" "IO ()"
+v5 = StreamVertex 5 Sink ["mapM_ print"] "String" "IO ()"
 
-graph = overlay (path [v1, v3]) $ path [v2, v3, v4]
+graph = (overlays (map vertex [v1,v2,v3]) `connect` (vertex v4)) `overlay` path [v4,v5]
 
-parts = [[1],[2],[3,4]]
+parts = [[1],[2],[3],[4,5]]
 
 main = partitionGraph graph parts defaultOpts

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -43,33 +43,41 @@ createPartitions g (p:ps) = ((overlay vs es):tailParts, cutEdges `overlay` tailC
     edgesOut  = edges $ filter (\(v1,v2) -> (fv v1) && (not(fv v2))) (edgeList g)
     (tailParts, tailCuts) = createPartitions g ps
 
--- | In situations where the first operator of a partition is streamMerge,
--- remove it, since the merging will be achieved by the TCP/IP layer.
-stripMerge :: StreamGraph -> StreamGraph
-stripMerge g = let
-    allEdges         = edgeList g
-    allVertices      = vertexList g
-    internalVertices = map snd allEdges
-    outerMerges      = filter (\v -> operator v == Merge
-                               && not (v `elem` internalVertices)) allVertices
-    rewrite m = let
-        nextOp = head $ filter (\v -> (m,v) `elem` allEdges) allVertices
+-- | Builds a function to remove Merges from a StreamGraph, if they are
+-- connected to from operators in another (local) graph. We remove Merges
+-- from the beginning of Partitions and use the TCP/IP machinery to merge
+-- multiple incoming streams instead.
+mkStripMerge :: StreamGraph -> StreamGraph -> (StreamGraph -> StreamGraph)
+mkStripMerge local global = let
+    -- find Merges in global Graph connected to from local Graph
+    merges = map snd
+           $ filter (\(f,t)-> f `elem` vertexList local && operator t == Merge)
+           $ edgeList global
+
+    remove m = let nextOp = snd . head . filter ((==m).fst) . edgeList $ global
         in removeEdge nextOp nextOp . replaceVertex m nextOp
 
-    in foldl (&) g (map rewrite outerMerges)
+    in \g -> foldl (&) g (map remove merges)
 
-stripMergePre = path
-    [ StreamVertex 0 Merge [] "Int" "Int"
-    , StreamVertex 1 Map ["show","s"] "Int" "String"
-    , StreamVertex 2 Sink ["mapM_ print"] "String" "String"
+global = path
+    [ StreamVertex 0 Source [] "Int" "Int"
+    , StreamVertex 1 Merge [] "Int" "Int"
+    , StreamVertex 2 Map ["show","s"] "Int" "String"
+    , StreamVertex 3 Sink ["mapM_ print"] "String" "String"
     ]
+local = Vertex $ StreamVertex 0 Source [] "Int" "Int"
+
 stripMergePost = path
-    [ StreamVertex 1 Map ["show","s"] "Int" "String"
-    , StreamVertex 2 Sink ["mapM_ print"] "String" "String"
+    [ StreamVertex 0 Source [] "Int" "Int"
+    , StreamVertex 2 Map ["show","s"] "Int" "String"
+    , StreamVertex 3 Sink ["mapM_ print"] "String" "String"
     ]
-test_stripMerge_1 = assertEqual (stripMerge stripMergePre) stripMergePost
-test_stripMerge_2 = assertEqual (stripMerge stripMergePost) stripMergePost
 
+test_stripMerge1 = assertEqual stripMergePost $
+    mkStripMerge local global $ global
+
+test_stripMerge2 = assertEqual stripMergePost $
+    mkStripMerge local stripMergePost $ stripMergePost
 
 unPartition :: ([Graph StreamVertex], Graph StreamVertex) -> Graph StreamVertex
 unPartition (a,b) = overlay b $ foldl overlay Empty a

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -170,7 +170,8 @@ generateCodeFromStreamGraph opts parts cuts (partId,sg) = intercalate "\n" $
             [] -> ["n2 = n1"]
             ns -> map generateCodeFromVertex ns
         imports' = (map ("import "++) (imports opts)) ++ ["\n"]
-        lastIdentifier = 'n':(show $ (length intVerts) + valence)
+        lastIdentifier = 'n':(show $ length intVerts
+            + if startsWithJoin sg then 2 else 1)
         intVerts= filter (\x-> not $ operator x `elem` [Source,Sink]) $ vertexList sg
         valence = partValence sg cuts
         nodeFn sg = case (nodeType sg) of


### PR DESCRIPTION
This adjusts the  code generator in CompileIoT so that multiple incoming streams to a Partition are directed at the same TCP/IP port, the events interleaved by the Node.hs machinery, and a single logical stream presented to the receiving stream processing, which has any streamMerge operator at the head removed.

<s>WIP because this breaks streamJoin!</s> Ready