### PR TITLE
rework optimiseWriteOut as optimiseWriteOutAll

### DIFF
--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -3,7 +3,6 @@
 module Striot.LogicalOptimiser ( applyRules
                                , costModel
                                , optimise
-                               , optimiseWriteOut
 
                                , htf_thisModulesTests
                                ) where
@@ -62,20 +61,6 @@ optimise sg = let
     in if score > base
        then candidate
        else sg
-
--- | Optimise a StreamGraph and write the result out as Haskell source
--- code to the supplied FilePath, along with some of the necessary
--- supporting code.
-optimiseWriteOut :: FilePath -> StreamGraph -> IO ()
-optimiseWriteOut fn =
-    writeFile fn . template . show . simplify . optimise
-
-template g = intercalate "\n"
-    [ "import Striot.StreamGraph"
-    , "import Algebra.Graph"
-    , "\n"
-    , "graph = " ++ g
-    ]
 
 ------------------------------------------------------------------------------
 

--- a/striot.cabal
+++ b/striot.cabal
@@ -53,6 +53,7 @@ library
                     , mtl               >= 2.2.2
                     , lens              >= 4.17.1
                     , envy              >= 2.0.0.0
+                    , utility-ht        >= 0.0.14
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -84,6 +85,7 @@ test-suite test-striot
                     , mtl               >= 2.2.2
                     , lens              >= 4.17.1
                     , envy              >= 2.0.0.0
+                    , utility-ht        >= 0.0.14
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing


### PR DESCRIPTION
Rework optimiseWriteOut as optimiseWriteOutAll so that it writes out a
file containing a list of all rewritten variants of the input stream
graph, paired with all possible mappings of those graphs to partitions.

Move the function from LogicalOptimiser to CompileIoT.

Add supporting functions (not exported) "partitionings", which
calculates a mapping of a StreamGraph onto Partitions, and a placeholder
implementation of allPartitionings.