### PR TITLE
Implement allPartitionings

### DIFF
--- a/striot.cabal
+++ b/striot.cabal
@@ -37,7 +37,7 @@ library
                     , HTF
                     , bytestring        >= 0.9.2
                     , unagi-chan        >= 0.4.1.0
-                    , algebraic-graphs  >= 0.1
+                    , algebraic-graphs  >= 0.3
                     , filepath          >= 1.4
                     , directory         >= 1.3
                     , store
@@ -69,7 +69,7 @@ test-suite test-striot
                     , HTF
                     , bytestring        >= 0.9.2
                     , unagi-chan        >= 0.4.1.0
-                    , algebraic-graphs  >= 0.1
+                    , algebraic-graphs  >= 0.3
                     , filepath          >= 1.4
                     , directory         >= 1.3
                     , store


### PR DESCRIPTION
Algorithm to determine all partitionings works by traversing the
transposed StreamGraph from Sink (which is a tree), extending
existing open partitionings depending on the operator type. Sink
and Source nodes cannot coexist in the same partition; Merge
operators force the allocation of a new partition.

The traversal is achieved by implementing a "foldl" to apply to
graphs.

allPartitionings returns all generated partitioning schemes that
use the same number of partitions as that supplied by the user,
excluding those that use fewer.