### PR TITLE
connectNodeId: runtime check for missing cut edges

### DIFF
--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -288,7 +288,9 @@ connectNodeId sg parts cuts = let
     destVs= map snd outEs
     destGs= concatMap (\v -> filter (\(n,sg) -> v `elem` (vertexList sg)) parts) destVs
 
-    in map fst destGs
+    in case map fst destGs of
+        [] -> error "connectNodeId returned an empty list, last vertex optimised away?"
+        x  -> x
 
 generateSrcFn :: StreamGraph -> String
 generateSrcFn sg = "src1 = " ++


### PR DESCRIPTION
This has tripped me up twice now so this is a very minor improvement
to the current situation.

We partition graphs prior to optimisation, and capture the inter-graph
links a that point, keying off the vertices at that time. Optimisation
may remove the last vertex in a sub-graph (or replace it with another)
in which case a later look-up of the inter-graph connections will fail
to find it.

A more proper fix would be to make the inter-graph links resilient to
the vertices being removed or changed. However, we're also moving to
a workflow where we don't optimise the sub-graphs, instead optimising
the whole thing prior to partitioning, so this problem goes away once
we've completed that work.