### PR TITLE
Prom version + non-ascii character

### DIFF
--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -278,7 +278,7 @@ test_inType = assertEqual "Int" $
 
 -- determine the node(s?) to connect on to from this partition
 -- XXX always 0 or 1? write quickcheck property...
--- TODO: this breaks if the outer-edge node has been optimised away…
+-- TODO: this breaks if the outer-edge node has been optimised away...
 -- the graph of cut edges has the pre-optimisation StreamVertex in it.
 connectNodeId :: StreamGraph -> [(Integer, StreamGraph)] -> StreamGraph -> [Integer]
 connectNodeId sg parts cuts = let

--- a/src/Striot/Nodes.hs
+++ b/src/Striot/Nodes.hs
@@ -41,7 +41,7 @@ import           System.IO.Unsafe
 import           System.Metrics.Prometheus.Concurrent.Registry as PR (new, registerCounter,
                                                                       registerGauge,
                                                                       sample)
-import           System.Metrics.Prometheus.Http.Scrape         (serveHttpTextMetrics)
+import           System.Metrics.Prometheus.Http.Scrape         (serveMetrics)
 import           System.Metrics.Prometheus.Metric.Counter      as PC (inc)
 import           System.Metrics.Prometheus.MetricId            (addLabel)
 
@@ -324,7 +324,7 @@ startPrometheus name = do
         registerFn fn mName = fn mName lbl reg
         rg = registerFn registerGauge
         rc = registerFn registerCounter
-    async $ serveHttpTextMetrics 8080 ["metrics"] (PR.sample reg)
+    async $ serveMetrics 8080 ["metrics"] (PR.sample reg)
     Metrics
         <$> rg "striot_ingress_connection"
         <*> rc "striot_ingress_bytes_total"

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
 - .
 extra-deps:
 - network-3.1.0.0
-- prometheus-2.1.2
+- prometheus-2.2.2
 - store-streaming-0.1.0.0
 - unagi-chan-0.4.1.0
 - net-mqtt-0.6.2.1

--- a/striot.cabal
+++ b/striot.cabal
@@ -43,7 +43,7 @@ library
                     , store
                     , store-streaming   >= 0.1.0
                     , async
-                    , prometheus        >= 2.1.2
+                    , prometheus        >= 2.2.2
                     , net-mqtt          >= 0.6.2.1
                     , text
                     , process
@@ -77,7 +77,7 @@ test-suite test-striot
                     , store
                     , store-streaming   >= 0.1.0
                     , async
-                    , prometheus        >= 2.1.2
+                    , prometheus        >= 2.2.2
                     , net-mqtt          >= 0.6.2.1
                     , text
                     , process


### PR DESCRIPTION
Prometheus latest version changed the API from `serveHttpTextMetrics` to `serveMetrics`.

Removed non-ascii character.