### PR TITLE
remove windowExpandWindow rewrite: not valid

### DIFF
--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -79,7 +79,6 @@ rules = [ filterFuse
         , expandMap
         , expandScan
         , expandExpand
-        , windowExpandWindow
         , mergeFilter
         , mergeExpand
         , mergeMap
@@ -540,46 +539,6 @@ expandExpandPost = path
 
 test_expandExpand = assertEqual (applyRule expandExpand expandExpandPre)
     expandExpandPost
-
--- streamWindow w >>> streamExpand >>> streamWindow w == streamWindow w ------
-
-windowExpandWindow :: RewriteRule
-windowExpandWindow g =
-    let vs = take 3 (vertexList g)
-        appropriate = map operator vs == [Window, Expand, Window] &&
-                      (map deQ . parameters . head) vs
-                      == (map deQ . parameters . last) vs
-        [w,e,w'] = vs
-    in if   not appropriate then Nothing
-       else Just (simplify . removeEdge w' w' . mergeVertices (`elem` [w,e]) w')
-
-windowExpandWindowPre = path
-    [ StreamVertex 0 Window [[| chop 2 |]] "Int" "[Int]"
-    , StreamVertex 1 Expand [] "[Int]" "Int"
-    , StreamVertex 2 Window [[| chop 2 |]] "Int" "[Int]"
-    ]
-windowExpandWindowPost = Vertex $ StreamVertex 2 Window [[| chop 2 |]] "Int" "[Int]"
-
-test_windowExpandWindow = assertEqual (applyRule windowExpandWindow windowExpandWindowPre)
-    windowExpandWindowPost
-
--- additional test to ensure that edges from nodes outside of the matching sub-graph
--- are correctly rewritten 
-windowExpandWindowPre2 = path
-    [ StreamVertex 0 Source [] "Int" "Int"
-    , StreamVertex 1 Window [[| chop 2 |]] "Int" "[Int]"
-    , StreamVertex 2 Expand [] "[Int]" "Int"
-    , StreamVertex 3 Window [[| chop 2 |]] "Int" "[Int]"
-    , StreamVertex 4 Sink [] "[Int]" "[Int]"
-    ]
-windowExpandWindowPost2 = path
-    [ StreamVertex 0 Source [] "Int" "Int"
-    , StreamVertex 3 Window [[| chop 2 |]] "Int" "[Int]"
-    , StreamVertex 4 Sink [] "[Int]" "[Int]"
-    ]
-
-test_windowExpandWindow2 = assertEqual (applyRule windowExpandWindow windowExpandWindowPre2)
-    windowExpandWindowPost2
 
 -- streamFilter f (streamMerge [s1, s2]) -------------------------------------
 -- = streamMerge [streamFilter f s1, streamFilter f s2]


### PR DESCRIPTION
This is not a valid rewrite rule. Consider a window maker that
operates on the timestamps of Events: they are not preserved
after the first windowing.

Concrete example: a window maker that grouped successive Events
as long as the had a different timestamp. Consider this input

    this input 1,2,3,4,5,5,4,3,2,1
    first window [1,2,3,4,5],[5,4,3,2,1]
    expanded [1,1,1,1,1,5,5,5,5,5]
        note: timestamps here are copied from the windows
    second window [[1],[1],[1],[1],[1,5],[5],[5],[5],[5]]