### PR TITLE
Manually install different happy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo apt-get update && sudo apt-get install librdkafka-dev
 
 install:
-  - cabal install happy alex
+  - cabal install happy-1.19.12 alex
   - cabal install c2hs
   - cabal install --only-dependencies --enable-tests --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
 


### PR DESCRIPTION
HTF uses a deprecated package `haskell-src` which has a dependency on an older version of `happy`.

To satisfy for now I have enforced installing the version of happy it needs.

Seeing as HTF hasn't been updated for nearly a year, and that it seems to be the source of a few of our build failures it may be worth moving to HUnit/QuickCheck/HSpec - but that's a discussion for a different thread.