### PR TITLE
Add Jackson Network parameters and calculations for Cost Models

### DIFF
--- a/examples/costModel/overUtilisation/OverUt.hs
+++ b/examples/costModel/overUtilisation/OverUt.hs
@@ -1,0 +1,46 @@
+{-# OPTIONS_GHC -F -pgmF htfpp #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- demonstrate detecting over-utilisation
+
+
+module OverUt where
+
+import Algebra.Graph
+import Data.Function ((&))
+import Data.Maybe
+import Striot.CompileIoT
+import Striot.Jackson hiding (serviceTime)
+import Striot.LogicalOptimiser
+import Striot.StreamGraph
+import Striot.VizGraph
+import System.Random
+import Test.Framework hiding ((===))
+
+source = [| do
+    i <- getStdRandom (randomR (1,10)) :: IO Int
+    threadDelay 1000000
+    putStrLn $ "client sending " ++ (show i)
+    return i
+    |]
+
+graph = path
+    [ StreamVertex 0 (Source 8)     [ source         ] "Int" "Int" 0
+    , StreamVertex 1 (Filter (1/2)) [[|(>5)        |]] "Int" "Int" 0
+    , StreamVertex 4 Merge          []                 "Int" "Int" (1/5)
+    , StreamVertex 5 Sink           [[|mapM_ print |]] "Int" "Int" 0
+    ]
+
+-- the rewritten graph has the filter moved after the merge, so the
+-- merge receives the full arrival rate into the system
+test_match = assertBool $ isJust $ firstMatch graph filterMerge
+rewritten  = graph & fromJust (firstMatch graph filterMerge)
+
+test_opIds = assertEqual [0,1,4,5] $ map opId (calcAllSg graph)
+
+isOverUtilised :: StreamGraph -> Bool
+isOverUtilised = any (>1) . map util . calcAllSg
+
+test_isOverUtilised = assertBool $ isOverUtilised rewritten
+
+main = htfMain htf_thisModulesTests

--- a/examples/expand/generate.hs
+++ b/examples/expand/generate.hs
@@ -26,7 +26,7 @@ source = [| do
     return s
     |]
 
-v1 = StreamVertex 1 Source [source]                              "String" "String" 0
+v1 = StreamVertex 1 (Source 1) [source]                              "String" "String" 0
 v2 = StreamVertex 2 Map    [[| filter (('#'==).head) . words |]] "String" "[String]" 1
 
 v5 = StreamVertex 5 Expand []                                    "[String]" "String" 1

--- a/examples/expand/generate.hs
+++ b/examples/expand/generate.hs
@@ -26,11 +26,11 @@ source = [| do
     return s
     |]
 
-v1 = StreamVertex 1 Source [source]                              "String" "String"
-v2 = StreamVertex 2 Map    [[| filter (('#'==).head) . words |]] "String" "[String]"
+v1 = StreamVertex 1 Source [source]                              "String" "String" 0
+v2 = StreamVertex 2 Map    [[| filter (('#'==).head) . words |]] "String" "[String]" 1
 
-v5 = StreamVertex 5 Expand []                                    "[String]" "String"
-v6 = StreamVertex 6 Sink   [[| mapM_ print |]]                   "String" "String"
+v5 = StreamVertex 5 Expand []                                    "[String]" "String" 1
+v6 = StreamVertex 6 Sink   [[| mapM_ print |]]                   "String" "String" 0
 
 graph = path [v1, v2, v5, v6]
 

--- a/examples/filter/generate.hs
+++ b/examples/filter/generate.hs
@@ -19,7 +19,7 @@ source = [| do
     |]
 
 ssi =
- [ (Source , [source], "Int", 0)
+ [ ((Source 1) , [source], "Int", 0)
  , ((Filter 0.5), [[| (>5) |]], "Int", 1)
  , ((Filter 0.5), [[| (<8) |]], "Int", 1)
  , (Map    , [[| id   |]], "Int", 1) -- work around bug #88

--- a/examples/filter/generate.hs
+++ b/examples/filter/generate.hs
@@ -19,12 +19,12 @@ source = [| do
     |]
 
 ssi =
- [ (Source , [source], "Int")
- , (Filter , [[| (>5) |]], "Int")
- , (Filter , [[| (<8) |]], "Int")
- , (Map    , [[| id   |]], "Int") -- work around bug #88
- , (Window , [[| chop 1 |]], "[Int]")
- , (Sink   , [[| mapM_ $ putStrLn . ("receiving "++) . show . value |]], "[String]")
+ [ (Source , [source], "Int", 0)
+ , ((Filter 0.5), [[| (>5) |]], "Int", 1)
+ , ((Filter 0.5), [[| (<8) |]], "Int", 1)
+ , (Map    , [[| id   |]], "Int", 1) -- work around bug #88
+ , (Window , [[| chop 1 |]], "[Int]", 1)
+ , (Sink   , [[| mapM_ $ putStrLn . ("receiving "++) . show . value |]], "[String]", 0)
  ]
 
 graph = simpleStream ssi

--- a/examples/filterAcc/generate.hs
+++ b/examples/filterAcc/generate.hs
@@ -18,7 +18,7 @@ source = [| do
         return s
     |]
 
-v1 = StreamVertex 1 Source    [source]                                 "String" "String" 0
+v1 = StreamVertex 1 (Source 1)    [source]                                 "String" "String" 0
 v2 = StreamVertex 2 Map       [[| id |]]                               "String" "String" 1
 v3 = StreamVertex 3 (FilterAcc 1) [[| \_ e -> e |], [| "0" |], [| (/=) |]] "String" "String" 1
 v4 = StreamVertex 4 Window    [[| chop 1 |]]                           "String" "[String]" 1

--- a/examples/filterAcc/generate.hs
+++ b/examples/filterAcc/generate.hs
@@ -18,12 +18,12 @@ source = [| do
         return s
     |]
 
-v1 = StreamVertex 1 Source    [source]                                 "String" "String"
-v2 = StreamVertex 2 Map       [[| id |]]                               "String" "String"
-v3 = StreamVertex 3 FilterAcc [[| \_ e -> e |], [| "0" |], [| (/=) |]] "String" "String"
-v4 = StreamVertex 4 Window    [[| chop 1 |]]                           "String" "[String]"
+v1 = StreamVertex 1 Source    [source]                                 "String" "String" 0
+v2 = StreamVertex 2 Map       [[| id |]]                               "String" "String" 1
+v3 = StreamVertex 3 (FilterAcc 1) [[| \_ e -> e |], [| "0" |], [| (/=) |]] "String" "String" 1
+v4 = StreamVertex 4 Window    [[| chop 1 |]]                           "String" "[String]" 1
 v5 = StreamVertex 5 Sink      [[| mapM_ $ putStrLn . ("receiving "++) . show . value |]]
-                                                                       "[String]" "IO ()"
+                                                                       "[String]" "IO ()" 0
 
 graph = path [v1, v2, v3, v4, v5]
 

--- a/examples/join/generate.hs
+++ b/examples/join/generate.hs
@@ -10,9 +10,9 @@ source x = [| do
     return x'
     |]
 
-v1 = StreamVertex 1 Source [source "foo"]    "String" "String" 0
+v1 = StreamVertex 1 (Source 1) [source "foo"]    "String" "String" 0
 v2 = StreamVertex 2 Map    [[| id |]]        "String" "String" 1
-v3 = StreamVertex 3 Source [source "bar"]    "String" "String" 0
+v3 = StreamVertex 3 (Source 1) [source "bar"]    "String" "String" 0
 v4 = StreamVertex 4 Map    [[| id |]]        "String" "String" 1
 v5 = StreamVertex 5 Join   []                "String" "(String, String)" 1
 v6 = StreamVertex 6 Sink   [[|mapM_ print|]] "(String, String)" "IO ()" 0

--- a/examples/join/generate.hs
+++ b/examples/join/generate.hs
@@ -10,12 +10,12 @@ source x = [| do
     return x'
     |]
 
-v1 = StreamVertex 1 Source [source "foo"]    "String" "String"
-v2 = StreamVertex 2 Map    [[| id |]]        "String" "String"
-v3 = StreamVertex 3 Source [source "bar"]    "String" "String"
-v4 = StreamVertex 4 Map    [[| id |]]        "String" "String"
-v5 = StreamVertex 5 Join   []                "String" "(String, String)"
-v6 = StreamVertex 6 Sink   [[|mapM_ print|]] "(String, String)" "IO ()"
+v1 = StreamVertex 1 Source [source "foo"]    "String" "String" 0
+v2 = StreamVertex 2 Map    [[| id |]]        "String" "String" 1
+v3 = StreamVertex 3 Source [source "bar"]    "String" "String" 0
+v4 = StreamVertex 4 Map    [[| id |]]        "String" "String" 1
+v5 = StreamVertex 5 Join   []                "String" "(String, String)" 1
+v6 = StreamVertex 6 Sink   [[|mapM_ print|]] "(String, String)" "IO ()" 0
 
 graph = overlay (path [v3, v4, v5]) $ path [v1, v2, v5, v6]
 

--- a/examples/merge/generate.hs
+++ b/examples/merge/generate.hs
@@ -14,13 +14,13 @@ source x y = [| do
     return z
     |]
 
-v1 = StreamVertex 1 Source [source "foo" (1000*1000)] "String" "String"
-v2 = StreamVertex 2 Source [source "bar"  (500*1000)] "String" "String"
-v3 = StreamVertex 3 Source [source "baz"  (200*1000)] "String" "String"
+v1 = StreamVertex 1 Source [source "foo" (1000*1000)] "String" "String" 0
+v2 = StreamVertex 2 Source [source "bar"  (500*1000)] "String" "String" 0
+v3 = StreamVertex 3 Source [source "baz"  (200*1000)] "String" "String" 0
 
-v4 = StreamVertex 4 Merge [] "String" "String"
+v4 = StreamVertex 4 Merge [] "String" "String" 1
 -- XXX: ^ we lie about the input type here, because the generated function has split-out arguments
-v5 = StreamVertex 5 Sink [[| mapM_ print |]] "String" "IO ()"
+v5 = StreamVertex 5 Sink [[| mapM_ print |]] "String" "IO ()" 0
 
 graph = (overlays (map vertex [v1,v2,v3]) `connect` (vertex v4)) `overlay` path [v4,v5]
 

--- a/examples/merge/generate.hs
+++ b/examples/merge/generate.hs
@@ -14,9 +14,9 @@ source x y = [| do
     return z
     |]
 
-v1 = StreamVertex 1 Source [source "foo" (1000*1000)] "String" "String" 0
-v2 = StreamVertex 2 Source [source "bar"  (500*1000)] "String" "String" 0
-v3 = StreamVertex 3 Source [source "baz"  (200*1000)] "String" "String" 0
+v1 = StreamVertex 1 (Source 1) [source "foo" (1000*1000)] "String" "String" 0
+v2 = StreamVertex 2 (Source 1) [source "bar"  (500*1000)] "String" "String" 0
+v3 = StreamVertex 3 (Source 1) [source "baz"  (200*1000)] "String" "String" 0
 
 v4 = StreamVertex 4 Merge [] "String" "String" 1
 -- XXX: ^ we lie about the input type here, because the generated function has split-out arguments

--- a/examples/pipeline/generate.hs
+++ b/examples/pipeline/generate.hs
@@ -12,12 +12,12 @@ graph = path
     [ StreamVertex 1 Source [[| do
             threadDelay (1000*1000)
             return "Hello from Client!"
-        |]] "String" "String"
-    , StreamVertex 2 Map    [[| \st->st++st |]] "String" "String"
-    , StreamVertex 3 Map    [[| reverse |]]     "String" "String"
-    , StreamVertex 4 Map    [[| \st->"Incoming Message at Server: " ++ st |]] "String" "String"
-    , StreamVertex 5 Window [[| chop 2 |]]      "String" "[String]"
-    , StreamVertex 6 Sink   [[| mapM_ print |]] "[String]" "IO ()"
+        |]] "String" "String" 0
+    , StreamVertex 2 Map    [[| \st->st++st |]] "String" "String" 1
+    , StreamVertex 3 Map    [[| reverse |]]     "String" "String" 1
+    , StreamVertex 4 Map    [[| \st->"Incoming Message at Server: " ++ st |]] "String" "String" 1
+    , StreamVertex 5 Window [[| chop 2 |]]      "String" "[String]" 1
+    , StreamVertex 6 Sink   [[| mapM_ print |]] "[String]" "IO ()" 0
     ]
 
 main = partitionGraph graph [[1,2],[3],[4,5,6]] opts

--- a/examples/pipeline/generate.hs
+++ b/examples/pipeline/generate.hs
@@ -9,7 +9,7 @@ import Algebra.Graph
 opts = defaultOpts { rewrite = False }
 
 graph = path
-    [ StreamVertex 1 Source [[| do
+    [ StreamVertex 1 (Source 1) [[| do
             threadDelay (1000*1000)
             return "Hello from Client!"
         |]] "String" "String" 0

--- a/examples/scan/generate.hs
+++ b/examples/scan/generate.hs
@@ -10,7 +10,7 @@ source x = [| do
     return x'
     |]
 
-v1 = StreamVertex 1 Source [source "foo"] "String" "String" 0
+v1 = StreamVertex 1 (Source 1) [source "foo"] "String" "String" 0
 v2 = StreamVertex 2 Map    [[| id |]] "String" "String" 1
 
 v5 = StreamVertex 5 Scan   [[| \old _ -> old + 1 |], [|0|]] "String" "Int" 1

--- a/examples/scan/generate.hs
+++ b/examples/scan/generate.hs
@@ -10,11 +10,11 @@ source x = [| do
     return x'
     |]
 
-v1 = StreamVertex 1 Source [source "foo"] "String" "String"
-v2 = StreamVertex 2 Map    [[| id |]] "String" "String"
+v1 = StreamVertex 1 Source [source "foo"] "String" "String" 0
+v2 = StreamVertex 2 Map    [[| id |]] "String" "String" 1
 
-v5 = StreamVertex 5 Scan   [[| \old _ -> old + 1 |], [|0|]] "String" "Int"
-v6 = StreamVertex 6 Sink   [[| mapM_ print |]] "Int" "IO ()"
+v5 = StreamVertex 5 Scan   [[| \old _ -> old + 1 |], [|0|]] "String" "Int" 1
+v6 = StreamVertex 6 Sink   [[| mapM_ print |]] "Int" "IO ()" 0
 
 graph = path [v1, v2, v5, v6]
 

--- a/examples/taxi/generate.hs
+++ b/examples/taxi/generate.hs
@@ -32,7 +32,7 @@ sink = [| mapM_ (print.show.fromJust.value) |]
 
 taxiQ1 :: StreamGraph
 taxiQ1 = simpleStream
-    [ (Source,    [source],                         "Trip", 0)
+    [ ((Source 1.2), [source],                         "Trip", 0)
     , (Window,    [[| tripTimes |]],                "[Trip]", 0.0001)
     , (Expand,    [],                               "Trip", 0.0001)
     , (Map,       [[| tripToJourney |]],            "Journey", 0.0001)

--- a/examples/taxi/generate.hs
+++ b/examples/taxi/generate.hs
@@ -32,16 +32,16 @@ sink = [| mapM_ (print.show.fromJust.value) |]
 
 taxiQ1 :: StreamGraph
 taxiQ1 = simpleStream
-    [ (Source,    [source],                         "Trip")
-    , (Window,    [[| tripTimes |]],                "[Trip]")
-    , (Expand,    [],                               "Trip")
-    , (Map,       [[| tripToJourney |]],            "Journey")
-    , (Filter,    [[| \j -> inRangeQ1 (start j) |]],"Journey")
-    , (Filter,    [[| \j -> inRangeQ1 (end j) |]],  "Journey")
-    , (Window,    [[| slidingTime 1800000 |]],      "[Journey]")
-    , (Map,       [topk'],                          "((UTCTime,UTCTime),[(Journey,Int)])")
-    , (FilterAcc, filterDupes,                      "((UTCTime,UTCTime),[(Journey,Int)])")
-    , (Sink,      [sink],                           "((UTCTime,UTCTime),[(Journey,Int)])")
+    [ (Source,    [source],                         "Trip", 0)
+    , (Window,    [[| tripTimes |]],                "[Trip]", 0.0001)
+    , (Expand,    [],                               "Trip", 0.0001)
+    , (Map,       [[| tripToJourney |]],            "Journey", 0.0001)
+    , ((Filter 0.95),    [[| \j -> inRangeQ1 (start j) |]],"Journey", 0.00005)
+    , ((Filter 0.95),    [[| \j -> inRangeQ1 (end j) |]],  "Journey", 0.00005)
+    , (Window,    [[| slidingTime 1800000 |]],      "[Journey]", 0.0001)
+    , (Map,       [topk'],                          "((UTCTime,UTCTime),[(Journey,Int)])", 0.01)
+    , ((FilterAcc 0.1), filterDupes,                "((UTCTime,UTCTime),[(Journey,Int)])", 0.0001)
+    , (Sink,      [sink],                           "((UTCTime,UTCTime),[(Journey,Int)])", 0.0001)
     ]
 
 parts = [[1..7],[8],[9..10]]

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -79,17 +79,17 @@ mkStripMerge local global = let
     in \g -> foldl (&) g (map remove merges)
 
 global = path
-    [ StreamVertex 0 Source [] "Int" "Int"
-    , StreamVertex 1 Merge [] "Int" "Int"
-    , StreamVertex 2 Map [[| show |]] "Int" "String"
-    , StreamVertex 3 Sink [[| mapM_ print |]] "String" "String"
+    [ StreamVertex 0 Source [] "Int" "Int" 1
+    , StreamVertex 1 Merge [] "Int" "Int" 2
+    , StreamVertex 2 Map [[| show |]] "Int" "String" 3
+    , StreamVertex 3 Sink [[| mapM_ print |]] "String" "String" 4
     ]
-local = Vertex $ StreamVertex 0 Source [] "Int" "Int"
+local = Vertex $ StreamVertex 0 Source [] "Int" "Int" 1
 
 stripMergePost = path
-    [ StreamVertex 0 Source [] "Int" "Int"
-    , StreamVertex 2 Map [[| show |]] "Int" "String"
-    , StreamVertex 3 Sink [[| mapM_ print |]] "String" "String"
+    [ StreamVertex 0 Source [] "Int" "Int" 1
+    , StreamVertex 2 Map [[| show |]] "Int" "String" 3
+    , StreamVertex 3 Sink [[| mapM_ print |]] "String" "String" 4
     ]
 
 test_stripMerge1 = assertEqual stripMergePost $
@@ -243,9 +243,9 @@ inType sg = let node = (head  . vertexList) sg
                then outtype node
                else intype node
 
-t = path [ StreamVertex 0 Source [[| return 0 |]]       "IO Int" "Int"
-         , StreamVertex 1 Map    [[| show |]]       "Int" "String"
-         , StreamVertex 2 Sink   [[| mapM_ putStrLn |]] "String" "IO ()"
+t = path [ StreamVertex 0 Source [[| return 0 |]]       "IO Int" "Int" 1
+         , StreamVertex 1 Map    [[| show |]]       "Int" "String" 2
+         , StreamVertex 2 Sink   [[| mapM_ putStrLn |]] "String" "IO ()" 3
          ]
 
 test_outType = assertEqual "String" $
@@ -315,10 +315,10 @@ startsWithJoin sg = let
     in length joinOps > 0 && (not . or . map (`elem` hasInputs) $ joinOps)
 
 test_startsWithJoin_1 = assertBool . startsWithJoin . path $
-    [StreamVertex 1 Join [] "" "", StreamVertex 0 Merge [] "" ""]
+    [StreamVertex 1 Join [] "" "" 1, StreamVertex 0 Merge [] "" "" 2]
 
 test_startsWithJoin_2 = assertBool . not . startsWithJoin . path $
-    [StreamVertex 0 Merge [] "" "", StreamVertex 1 Join [] "" ""]
+    [StreamVertex 0 Merge [] "" "" 3, StreamVertex 1 Join [] "" "" 4]
 
 test_startsWithJoin_3 = assertBool . not . startsWithJoin $ empty
 
@@ -373,13 +373,13 @@ partValence g cuts = let
 main = htfMain htf_thisModulesTests
 
 -- Source -> Sink
-s0 = connect (Vertex (StreamVertex 0 (Source) [] "String" "String"))
-    (Vertex (StreamVertex 1 (Sink) [] "String" "String"))
+s0 = connect (Vertex (StreamVertex 0 (Source) [] "String" "String" 1))
+             (Vertex (StreamVertex 1 (Sink) [] "String" "String" 2))
 
 -- Source -> Filter -> Sink
-s1 = path [ StreamVertex 0 (Source) [] "String" "String"
-          , StreamVertex 1 Filter [] "String" "String"
-          , StreamVertex 2 (Sink) [] "String" "String"
+s1 = path [ StreamVertex 0 (Source) [] "String" "String" 3
+          , StreamVertex 1 Filter [] "String" "String" 4
+          , StreamVertex 2 (Sink) [] "String" "String" 5
           ]
 
 test_reform_s0 = assertEqual s0 (unPartition $ createPartitions s0 [[0],[1]])
@@ -422,14 +422,14 @@ partitionGraph graph partitions opts = do
 -- the relevant `StreamOperator` for the node; the parameters and the *output*
 -- type. The other parameters to `StreamVertex` are inferred from the neighbouring
 -- tuples. Unique and ascending `vertexId` values are assigned.
-simpleStream :: [(StreamOperator, [ExpQ], String)] -> Graph StreamVertex
+simpleStream :: [(StreamOperator, [ExpQ], String, Double)] -> Graph StreamVertex
 simpleStream tupes = path lst
 
     where
-        intypes = "IO ()" : (map (\(_,_,ty) -> ty) (init tupes))
+        intypes = "IO ()" : (map (\(_,_,ty,_) -> ty) (init tupes))
         tupes3 = zip3 [1..] intypes tupes
-        lst = map (\ (i,intype,(op,params,outtype)) ->
-            StreamVertex i op params intype outtype) tupes3
+        lst = map (\ (i,intype,(op,params,outtype,sTime)) ->
+            StreamVertex i op params intype outtype sTime) tupes3
 
 ------------------------------------------------------------------------------
 
@@ -449,11 +449,11 @@ partitionings sg parts = let
         LT -> error "cannot partition a graph over more partitions than there are nodes"
 
 partTestGraph = path
-    [ StreamVertex 0 Source []        "Int" "Int"
-    , StreamVertex 1 Map [[| show |]] "Int" "String"
-    , StreamVertex 2 Filter [[| (<3) |]]    "Int" "Int"
-    , StreamVertex 3 Window []        "String" "[String]"
-    , StreamVertex 4 Sink []          "String" "String"
+    [ StreamVertex 0 Source []        "Int" "Int" 1
+    , StreamVertex 1 Map [[| show |]] "Int" "String" 2
+    , StreamVertex 2 Filter [[| (<3) |]]    "Int" "Int" 3
+    , StreamVertex 3 Window []        "String" "[String]" 4
+    , StreamVertex 4 Sink []          "String" "String" 5
     ]
 
 test_partitionings_1 = assertEqual [[x]|x <- [0..4]] $
@@ -560,12 +560,12 @@ test_subGraphs2 = assertEqual (subGraphs 3 t2) []
 test_subGraphs3 = assertEqual (subGraphs 1 t1) [path [2,3]]
 test_subGraphs4 = assertEqual (subGraphs 1 t2) [removeVertex 1 t2]
 
-v0 = StreamVertex 0 Source [] "" ""
-v1 = StreamVertex 1 Map [] "" ""
-v2 = StreamVertex 2 Sink [] "" ""
-v3 = StreamVertex 3 Source [] "" ""
-v4 = StreamVertex 4 Merge [] "" ""
-v5 = StreamVertex 5 Map [] "" ""
+v0 = StreamVertex 0 Source [] "" "" 0
+v1 = StreamVertex 1 Map [] "" "" 1
+v2 = StreamVertex 2 Sink [] "" "" 2 
+v3 = StreamVertex 3 Source [] "" "" 3
+v4 = StreamVertex 4 Merge [] "" "" 4
+v5 = StreamVertex 5 Map [] "" "" 5
 g3 = overlay (path [v0, v1, v4, v2]) (path [v3, v5, v4])
 g4 = transpose g3
 

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -355,7 +355,9 @@ paren :: String -> String
 paren s = "("++s++")"
 
 printOp :: StreamOperator -> String
-printOp = (++) "stream" . show
+printOp (Filter _) = "streamFilter"
+printOp (FilterAcc _) = "streamFilterAcc"
+printOp op = "stream" ++ (show op)
 
 -- how many incoming edges to this partition?
 -- + how many source nodes
@@ -378,7 +380,7 @@ s0 = connect (Vertex (StreamVertex 0 (Source) [] "String" "String" 1))
 
 -- Source -> Filter -> Sink
 s1 = path [ StreamVertex 0 (Source) [] "String" "String" 3
-          , StreamVertex 1 Filter [] "String" "String" 4
+          , StreamVertex 1 (Filter 0.5) [] "String" "String" 4
           , StreamVertex 2 (Sink) [] "String" "String" 5
           ]
 
@@ -451,7 +453,7 @@ partitionings sg parts = let
 partTestGraph = path
     [ StreamVertex 0 Source []        "Int" "Int" 1
     , StreamVertex 1 Map [[| show |]] "Int" "String" 2
-    , StreamVertex 2 Filter [[| (<3) |]]    "Int" "Int" 3
+    , StreamVertex 2 (Filter 0.5) [[| (<3) |]]    "Int" "Int" 3
     , StreamVertex 3 Window []        "String" "[String]" 4
     , StreamVertex 4 Sink []          "String" "String" 5
     ]

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -19,6 +19,8 @@ module Striot.CompileIoT ( createPartitions
                          , generateNodeSrc
                          , connectNodeId
 
+                         , allOptimisations
+
                          , htf_thisModulesTests
                          ) where
 
@@ -36,6 +38,7 @@ import Language.Haskell.TH
 
 import Striot.StreamGraph
 import Striot.LogicalOptimiser
+import Striot.Jackson
 
 ------------------------------------------------------------------------------
 -- StreamGraph Partitioning
@@ -628,3 +631,16 @@ test_g3 = assertEqual
     , [[2,4],[1,0],[5],[3]]
     , [[2,4],[1,0],[5,3]]
     ] $ allPartitions g3
+
+------------------------------------------------------------------------------
+-- Jackson/cost model entry point functions
+-- No partitioning
+
+-- | derive all optimisations of the supplied StreamGraph, calculate all
+-- Jackson stuff from that
+
+allOptimisations :: StreamGraph -> [(StreamGraph, [OperatorInfo])]
+allOptimisations sg = let
+    sgs = nub $ applyRules 5 sg
+    out = map (\sg -> (sg, calcAllSg sg)) sgs
+    in out

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -79,15 +79,15 @@ mkStripMerge local global = let
     in \g -> foldl (&) g (map remove merges)
 
 global = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 Merge [] "Int" "Int" 2
     , StreamVertex 2 Map [[| show |]] "Int" "String" 3
     , StreamVertex 3 Sink [[| mapM_ print |]] "String" "String" 4
     ]
-local = Vertex $ StreamVertex 0 Source [] "Int" "Int" 1
+local = Vertex $ StreamVertex 0 (Source 1) [] "Int" "Int" 1
 
 stripMergePost = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 2 Map [[| show |]] "Int" "String" 3
     , StreamVertex 3 Sink [[| mapM_ print |]] "String" "String" 4
     ]
@@ -107,7 +107,6 @@ unPartition (a,b) = overlay b $ foldl overlay Empty a
 {-
     a well-formed streamgraph:
         always starts with a Source?
-        always has just one Source?
         always ends with a Sink?
         always has just one Sink?
         is entirely connected?
@@ -151,7 +150,7 @@ generateCode sg pm opts = let
 data NodeType = NodeSource | NodeSink | NodeLink deriving (Show)
 
 nodeType :: StreamGraph -> NodeType
-nodeType sg = if operator (head (vertexList sg)) == Source
+nodeType sg = if isSource $ operator (head (vertexList sg))
               then NodeSource
               else if (operator.head.reverse.vertexList) sg == Sink
                    then NodeSink
@@ -239,11 +238,11 @@ outType sg = let node = (last . vertexList) sg
 -- see outType for rationale
 inType :: StreamGraph -> String
 inType sg = let node = (head  . vertexList) sg
-            in if operator node == Source
+            in if isSource $ operator node
                then outtype node
                else intype node
 
-t = path [ StreamVertex 0 Source [[| return 0 |]]       "IO Int" "Int" 1
+t = path [ StreamVertex 0 (Source 1) [[| return 0 |]]       "IO Int" "Int" 1
          , StreamVertex 1 Map    [[| show |]]       "Int" "String" 2
          , StreamVertex 2 Sink   [[| mapM_ putStrLn |]] "String" "IO ()" 3
          ]
@@ -365,7 +364,7 @@ partValence :: StreamGraph -> StreamGraph -> Int
 partValence g cuts = let
     verts = vertexList g
     inEdges = filter (\e -> (snd e) `elem` verts) (edgeList cuts)
-    sourceNodes = filter (\v -> Source == operator v) (vertexList g)
+    sourceNodes = filter (isSource . operator) (vertexList g)
     in
         (length sourceNodes) + (length inEdges)
 
@@ -375,11 +374,11 @@ partValence g cuts = let
 main = htfMain htf_thisModulesTests
 
 -- Source -> Sink
-s0 = connect (Vertex (StreamVertex 0 (Source) [] "String" "String" 1))
+s0 = connect (Vertex (StreamVertex 0 ((Source 1)) [] "String" "String" 1))
              (Vertex (StreamVertex 1 (Sink) [] "String" "String" 2))
 
 -- Source -> Filter -> Sink
-s1 = path [ StreamVertex 0 (Source) [] "String" "String" 3
+s1 = path [ StreamVertex 0 ((Source 1)) [] "String" "String" 3
           , StreamVertex 1 (Filter 0.5) [] "String" "String" 4
           , StreamVertex 2 (Sink) [] "String" "String" 5
           ]
@@ -451,7 +450,7 @@ partitionings sg parts = let
         LT -> error "cannot partition a graph over more partitions than there are nodes"
 
 partTestGraph = path
-    [ StreamVertex 0 Source []        "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) []        "Int" "Int" 1
     , StreamVertex 1 Map [[| show |]] "Int" "String" 2
     , StreamVertex 2 (Filter 0.5) [[| (<3) |]]    "Int" "Int" 3
     , StreamVertex 3 Window []        "String" "[String]" 4
@@ -562,10 +561,10 @@ test_subGraphs2 = assertEqual (subGraphs 3 t2) []
 test_subGraphs3 = assertEqual (subGraphs 1 t1) [path [2,3]]
 test_subGraphs4 = assertEqual (subGraphs 1 t2) [removeVertex 1 t2]
 
-v0 = StreamVertex 0 Source [] "" "" 0
+v0 = StreamVertex 0 (Source 1) [] "" "" 0
 v1 = StreamVertex 1 Map [] "" "" 1
 v2 = StreamVertex 2 Sink [] "" "" 2 
-v3 = StreamVertex 3 Source [] "" "" 3
+v3 = StreamVertex 3 (Source 1) [] "" "" 3
 v4 = StreamVertex 4 Merge [] "" "" 4
 v5 = StreamVertex 5 Map [] "" "" 5
 g3 = overlay (path [v0, v1, v4, v2]) (path [v3, v5, v4])
@@ -599,13 +598,13 @@ extendPartitioning :: StreamVertex -> [[StreamVertex]] -> [[[StreamVertex]]]
 extendPartitioning n choice = let
   lastNode = last . last $ choice
   in if 1 < (length (filter singleton (n:(last choice))))
-     || operator lastNode `elem` [Merge,Source]
+     || (operator lastNode == Merge || isSource (operator lastNode))
      then [ choice ++ [[n]] ]
      else [ choice ++ [[n]]
           , init choice ++ [last choice ++ [n]]
           ]
 
-singleton v = operator v `elem` [Source,Sink]
+singleton v = operator v == Sink || isSource (operator v)
 
 g' = path [ v0 , v1 , v2 ]
 test_g' = assertEqual [ [[2],[1],[0]]

--- a/src/Striot/Jackson.hs
+++ b/src/Striot/Jackson.hs
@@ -1,0 +1,179 @@
+module Jackson where
+-- import FunctionalIoTtypes
+-- import FunctionalProcessing
+import Data.Array -- cabal install array
+import Matrix.LU -- cabal install dsp
+import Matrix.Matrix
+import Data.List
+
+-- References & Manuals
+-- https://en.wikipedia.org/wiki/Jackson_network
+-- http://www.ece.virginia.edu/mv/edu/715/lectures/QNet.pdf
+-- https://hackage.haskell.org/package/dsp 
+-- http://haskelldsp.sourceforge.net/doc/Matrix.LU.html
+-- https://hackage.haskell.org/package/array-0.5.1.1/docs/Data-Array.html
+-- http://haskelldsp.sourceforge.net/doc/Matrix.Matrix.html
+
+identity:: (Ix a, Integral a, Num b) => Array (a,a) b -> Array (a,a) b
+identity p = listArray (bounds p) $ [if row==column then 1 else 0| row<-[1..size],column<-[1..size]]
+                        where size = fst $ snd $ bounds p
+                        
+mm_subtract:: (Ix a, Integral a, Num b) => Array (a, a) b -> Array (a, a) b -> Array (a, a) b
+mm_subtract x y = listArray (bounds x) $ [(x Data.Array.! (row,column))-(y Data.Array.! (row,column))| row<-[1..size],column<-[1..size]] 
+                          where size = fst $ snd $ bounds x
+                          
+                          
+ma_mult:: (Ix a, Integral a, Num b) => Array (a, a) b -> b -> Array (a, a) b 
+ma_mult x v   = listArray (bounds x) $ [v*(x Data.Array.! (row,column))| row<-[1..size],column<-[1..size]] 
+                          where size = fst $ snd $ bounds x
+                          
+va_mult:: (Ix a, Integral a, Num b) => Array a b -> b -> Array a b 
+va_mult x val   = listArray (bounds x) $ [val*(x Data.Array.! row)| row<-[1..size]] 
+                          where size = snd $ bounds x
+                          
+vv_mult:: (Ix a, Integral a, Num b) => Array a b -> Array a b -> Array a b
+vv_mult v1 v2 = listArray (bounds v1) $ [(v1 Data.Array.! row)*(v2 Data.Array.!row) |row <- [1..size]]
+                          where size = snd $ bounds v1
+
+v_take:: Int -> Array Int b -> Array Int b
+v_take max v = listArray (1,max) $ [v Data.Array.! row |row <- [1..max]]
+
+-- Jackson Network: lambda = (I-P')^(-1)a where a = (alpha.p0i)i=1..J
+arrivalRate:: Array (Int, Int) Double -> Array Int Double -> Double -> Array Int Double  
+arrivalRate p p0i alpha =  mv_mult (inverse $ mm_subtract (identity p) (m_trans p)) aa
+                               where aa = va_mult p0i alpha
+  
+-- ρ = λ/μ is the utilization of the buffer (the average proportion of time which the server is occupied.  
+utilisation:: Array Int Double -> Array Int Double -> Array Int Double
+utilisation arrivalRates meanServiceTimes = vv_mult arrivalRates meanServiceTimes
+
+-- the average number of customers in the system is ρ/(1 − ρ)
+avgeNumberOfCustomersInSystem:: Array Int Double -> Array Int Double
+avgeNumberOfCustomersInSystem utilisations = listArray (bounds utilisations) $ 
+                                                       [(utilisations Data.Array.! row)/(1.0- (utilisations Data.Array.!row)) |row <- [1..size]]
+                                                 where size = snd $ bounds utilisations
+                                                 
+-- the average response time (total time a customer spends in the system) is 1/(μ − λ)
+avgeResponseTime:: Array Int Double -> Array Int Double -> Array Int Double
+avgeResponseTime arrivalRates meanServiceTimes = listArray (bounds arrivalRates) $ 
+                                                       [1.0/((1.0/(meanServiceTimes Data.Array.! row))-(arrivalRates Data.Array.!row)) |row <- [1..size]]
+                                                 where size = snd $ bounds arrivalRates
+
+stable:: Array Int Double -> Array Int Double -> Array Int Bool
+stable arrivalRates meanServiceTimes = let utils = utilisation arrivalRates meanServiceTimes in
+                                           listArray (bounds arrivalRates) $ 
+                                                       [(utils Data.Array.! row) < 1/0 |row <- [1..size]]
+                                                 where size = snd $ bounds arrivalRates
+
+--	the average time spent waiting in the queue is ρ/(μ – λ)
+avgeTimeInQueue:: Array Int Double -> Array Int Double -> Array Int Double
+avgeTimeInQueue arrivalRates meanServiceTimes = let utils = utilisation arrivalRates meanServiceTimes in
+                                                       listArray (bounds arrivalRates) $ 
+                                                       [(utils Data.Array.! row)/
+                                                        ((1.0/(meanServiceTimes Data.Array.! row))-(arrivalRates Data.Array.!row))  |row <- [1..size]]
+                                                    where size = snd $ bounds arrivalRates
+
+
+------ example from wikipedia page on Jackson networks
+wikiExample:: Array Int Double
+wikiExample = let p     = listArray ((1,1),(3,3)) $ [0  ,0.5,0.5,     -- node 1
+                                                     0  ,0  ,0  ,     -- node 2
+                                                     0  ,0  ,0   ] in -- node 3
+              let alpha = 5 in                                        -- 5 events per second arrive into the system
+              let p0i   = listArray (1,3) $         [0.5,0.5,0   ] in -- the input events are distributed evenly across nodes 1 and 2
+                  arrivalRate p p0i alpha
+
+--- Taxi Q1 example
+{--
+type Q1Output = ((UTCTime, UTCTime), [(Journey, Int)])
+frequentRoutes :: Stream Trip -> Stream Q1Output                                                          -- node 6  Input rate 1.188*0.1 = 0.1188 
+frequentRoutes s = streamFilterAcc (\_ h -> (False,h)) (True,undefined) testSndChange s                   -- node 5  Input rate 1.188 Selectivity (est. 0.1)
+                 $ streamMap (\w -> (let lj = last w in (pickupTime lj, dropoffTime lj), topk 10 w))      -- node 4  Input rate 1.188
+                 $ streamWindow (slidingTime 1800000)                                                     -- node 3  Input rate 1.2*0.99 = 1.188
+                 $ streamFilter (\j -> inRangeQ1 (start j) && inRangeQ1 (end j))                          -- node 2  Input rate 1.2/s Selectivity (est.) 0.95
+                 $ streamMap    tripToJourney s                                                           -- node 1  Input rate 1.2/s         
+
+Node, InputFrom, Input Rate, Selectivity, Output Rate
+0     -          -           -            1.2
+1     0 (1)      1.2         1            1.2
+2     1 (1)      1.2         0.95         1.188
+3     2 (0.95)   1.188       1            1.188
+4     3 (1)      1.188       1            1.188
+5     4 (1)      1.188       0.1          0.1188
+6     5 (0.1)    0.118       -            - 
+
+This is represented as follows:      
+-}
+       
+taxiQ1Array:: Array (Int,Int) Double
+taxiQ1Array = listArray ((1,1),(6,6)) $
+              -- Output Node
+              --  1    2    3    4    5     6
+               [  0   ,1   ,0   ,0   ,0    ,0  ,     -- node 1 streamMap
+                  0   ,0   ,0.95,0   ,0    ,0  ,     -- node 2 streamFilter
+                  0   ,0   ,0   ,1   ,0    ,0  ,     -- node 3 streamWindow
+                  0   ,0   ,0   ,0   ,1    ,0  ,     -- node 4 streamMap
+                  0   ,0   ,0   ,0   ,0    ,0.1,     -- node 5 streamFilterAcc
+                  0   ,0   ,0   ,0   ,0    ,0  ]     -- node 6 the output of Q1
+
+taxiQ1Inputs = listArray (1,6) $ [1,0,0,0,0,0] -- all events in the input stream are sent to node 1
+
+taxiQ1meanServiceTimes:: Array Int Double
+taxiQ1meanServiceTimes = listArray (1,6) [0.0001,0.0001,0.0001,0.01,0.0001,0.0001]
+
+ 
+taxiQ1arrivalRates:: Array Int Double
+taxiQ1arrivalRates = arrivalRate taxiQ1Array taxiQ1Inputs 1.2 -- the 1.2 is the arrival rate (in events per second) into the system
+
+
+
+taxiQ1utilisation = utilisation taxiQ1arrivalRates taxiQ1meanServiceTimes 
+
+taxiQ1avgeNumberCustomersInSystem = avgeNumberOfCustomersInSystem taxiQ1utilisation
+
+taxiQ1avgeResponseTime = avgeResponseTime taxiQ1arrivalRates taxiQ1meanServiceTimes
+
+taxiQ1avgeTimeInQueue = avgeTimeInQueue   taxiQ1arrivalRates taxiQ1meanServiceTimes
+
+data OperatorInfo = OperatorInfo { opId        :: Int
+                                 , arrRate     :: Double
+                                 , serviceTime :: Double
+                                 , util        :: Double
+                                 , stab        :: Bool
+                                 , custInSys   :: Double
+                                 , respTime    :: Double
+                                 , queueTime   :: Double
+                                 }
+                                 deriving (Show)
+                                 
+calcAll:: Array (Int,Int) Double -> Array Int Double -> Double -> Array Int Double -> [OperatorInfo]
+calcAll connections inputs alpha meanServiceTimes = let arrivalRates             = arrivalRate connections inputs alpha in
+                                                    let utilisations             = utilisation arrivalRates meanServiceTimes                in
+                                                    let stability                = stable      arrivalRates meanServiceTimes                in
+                                                    let avgeNumberOfCustInSystem = avgeNumberOfCustomersInSystem utilisations               in
+                                                    let avgeResponseTimes        = avgeResponseTime arrivalRates meanServiceTimes           in
+                                                    let avgeTimesInQueue         = avgeTimeInQueue  arrivalRates meanServiceTimes           in
+                                                           map (\id -> OperatorInfo id (arrivalRates             Data.Array.! id)
+                                                                                       (meanServiceTimes         Data.Array.! id)
+                                                                                       (utilisations             Data.Array.! id)
+                                                                                       (stability                Data.Array.! id)
+                                                                                       (avgeNumberOfCustInSystem Data.Array.! id)                                                                                               
+                                                                                       (avgeResponseTimes        Data.Array.! id)
+                                                                                       (avgeTimesInQueue         Data.Array.! id))
+                                                               [1.. (snd $ bounds arrivalRates)]
+                                                                              
+taxiQ1Calc:: [OperatorInfo]
+taxiQ1Calc = calcAll taxiQ1Array taxiQ1Inputs 1.2 taxiQ1meanServiceTimes
+
+
+-- basic tests
+ex1   = listArray ((1,1),(3,3)) $ [1,0,0,-0.5,1,0,-0.5,0,1]                    
+test1 = (listArray ((1,1), (3,3)) $ [1,0,0,0,1,0,0,0,1]) Data.Array.! (1,1)
+test2 = print $ inverse $ listArray ((1,1), (3,3)) $ [1,0,0,0,1,0,0,0,1]
+test3 = print $ inverse $ listArray ((1,1), (3,3)) $ [1,0,0,-0.5,1,0,-0.5,0,1]
+test4 = print $ mv_mult (inverse $ listArray ((1,1), (3,3)) $ [1,0,0,-0.5,1,0,-0.5,0,1]) 
+                        (listArray (1,3) $ [2.5,2.5,0])
+test5 = identity ex1
+test6 = mm_subtract ex1 ex1
+test7 = m_trans ex1
+test8 = mm_subtract (identity ex1) (m_trans ex1)

--- a/src/Striot/Jackson.hs
+++ b/src/Striot/Jackson.hs
@@ -45,15 +45,36 @@ import Algebra.Graph
 
 -- |Derive the identity matrix from a 2D Array
 identity:: (Ix a, Integral a, Num b) => Array (a,a) b -> Array (a,a) b
-identity p = listArray (bounds p) $ [if row==column then 1 else 0| row<-[1..size],column<-[1..size]]
-                        where size = fst $ snd $ bounds p
+identity p = listArray (bounds p) $ [if row==column then 1 else 0| row<-[xfrom..xto],column<-[yfrom..yto]]
+                        where ((xfrom,yfrom),(xto,yto)) = bounds p
                         
+test_identity = assertEqual (identity (listArray ((1,1),(3,3)) $ [0 | x <- [1..9]])) $
+    (array ((1,1),(3,3)) [((1,1),1.0), ((1,2),0.0), ((1,3),0.0),
+                          ((2,1),0.0), ((2,2),1.0), ((2,3),0.0),
+                          ((3,1),0.0), ((3,2),0.0), ((3,3),1.0)] :: Array (Int,Int) Double)
+
+test_identity2= assertEqual (identity (listArray ((0,0),(2,2)) $ [0 | x <- [1..9]])) $
+    (array ((0,0),(2,2)) [((0,0),1.0), ((0,1),0.0), ((0,2),0.0),
+                          ((1,0),0.0), ((1,1),1.0), ((1,2),0.0),
+                          ((2,0),0.0), ((2,1),0.0), ((2,2),1.0)] :: Array (Int,Int) Double)
+
 -- |Matrix subtraction.
--- The indexes must begin at 1.
 mm_subtract:: (Ix a, Integral a, Num b) => Array (a, a) b -> Array (a, a) b -> Array (a, a) b
-mm_subtract x y = listArray (bounds x) $ [(x Data.Array.! (row,column))-(y Data.Array.! (row,column))| row<-[1..size],column<-[1..size]] 
-                          where size = fst $ snd $ bounds x
-                          
+mm_subtract x y = listArray (bounds x) $ [(x Data.Array.! (row,column))-(y Data.Array.! (row,column))| row<-[xfrom..xto],column<-[yfrom..yto]]
+                        where ((xfrom,yfrom),(xto,yto)) = bounds x
+
+test_mm_subtract1 = assertEqual (mm_subtract a b) c
+    where
+        a = listArray ((1,1),(3,3)) [3.0::Double | x <- [1..9]]
+        b = listArray ((1,1),(3,3)) [2.0::Double | x <- [1..9]]
+        c = listArray ((1,1),(3,3)) [1.0::Double | x <- [1..9]]
+
+test_mm_subtract2 = assertEqual (mm_subtract a b) c
+    where
+        a = listArray ((0,0),(2,2)) [3.0::Double | x <- [1..9]]
+        b = listArray ((0,0),(2,2)) [2.0::Double | x <- [1..9]]
+        c = listArray ((0,0),(2,2)) [1.0::Double | x <- [1..9]]
+
 -- | Matrix multiplication.
 -- The indexes must begin at 1.
 ma_mult:: (Ix a, Integral a, Num b) => Array (a, a) b -> b -> Array (a, a) b 
@@ -61,11 +82,10 @@ ma_mult x v   = listArray (bounds x) $ [v*(x Data.Array.! (row,column))| row<-[1
                           where size = fst $ snd $ bounds x
                           
 -- | Vector (1D Array) multiplication by value.
--- The indexes must begin at 1.
 va_mult:: (Ix a, Integral a, Num b) => Array a b -> b -> Array a b 
-va_mult x val   = listArray (bounds x) $ [val*(x Data.Array.! row)| row<-[1..size]] 
-                          where size = snd $ bounds x
-                          
+va_mult x val   = listArray (bounds x) [val*(x ! row) | row <- [from..to]]
+                          where (from,to) = bounds x
+
 -- | Vector (1D Array) multiplication.
 -- The indexes must begin at 1.
 vv_mult:: (Ix a, Integral a, Num b) => Array a b -> Array a b -> Array a b

--- a/src/Striot/Jackson.hs
+++ b/src/Striot/Jackson.hs
@@ -1,11 +1,27 @@
 {-# OPTIONS_GHC -F -pgmF htfpp #-}
 
-module Striot.Jackson ( arrivalRate
-                      , utilisation
-                      , avgeResponseTime
-                      , avgeTimeInQueue
-                      , avgeNumberOfCustomersInSystem
-                      ) where
+module Striot.Jackson ( OperatorInfo(..)
+                      , calcAll
+
+                      , arrivalRate
+                      , arrivalRate'
+
+                      , derivePropagationArray
+                      , deriveServiceTimes
+                      , deriveInputsArray
+                      , calcAllSg
+
+                      -- defined
+                      , taxiQ1Array
+                      , taxiQ1Inputs
+                      , taxiQ1meanServiceTimes
+                      -- calculated
+                      , taxiQ1arrivalRates
+                      , taxiQ1utilisation
+                      , taxiQ1Calc
+
+
+                      , htf_thisModulesTests) where
 
 -- import FunctionalIoTtypes
 -- import FunctionalProcessing

--- a/src/Striot/Jackson.hs
+++ b/src/Striot/Jackson.hs
@@ -163,21 +163,23 @@ data OperatorInfo = OperatorInfo { opId        :: Int
                                  deriving (Show)
                                  
 calcAll:: Array (Int,Int) Double -> Array Int Double -> Double -> Array Int Double -> [OperatorInfo]
-calcAll connections inputs alpha meanServiceTimes = let arrivalRates             = arrivalRate connections inputs alpha in
-                                                    let utilisations             = utilisation arrivalRates meanServiceTimes                in
-                                                    let stability                = stable      arrivalRates meanServiceTimes                in
-                                                    let avgeNumberOfCustInSystem = avgeNumberOfCustomersInSystem utilisations               in
-                                                    let avgeResponseTimes        = avgeResponseTime arrivalRates meanServiceTimes           in
-                                                    let avgeTimesInQueue         = avgeTimeInQueue  arrivalRates meanServiceTimes           in
-                                                           map (\id -> OperatorInfo id (arrivalRates             Data.Array.! id)
-                                                                                       (meanServiceTimes         Data.Array.! id)
-                                                                                       (utilisations             Data.Array.! id)
-                                                                                       (stability                Data.Array.! id)
-                                                                                       (avgeNumberOfCustInSystem Data.Array.! id)                                                                                               
-                                                                                       (avgeResponseTimes        Data.Array.! id)
-                                                                                       (avgeTimesInQueue         Data.Array.! id))
-                                                               [1.. (snd $ bounds arrivalRates)]
-                                                                              
+calcAll connections inputs alpha meanServiceTimes = let
+    arrivalRates             = arrivalRate connections inputs alpha
+    utilisations             = utilisation arrivalRates meanServiceTimes
+    stability                = stable arrivalRates meanServiceTimes
+    avgeNumberOfCustInSystem = avgeNumberOfCustomersInSystem utilisations
+    avgeResponseTimes        = avgeResponseTime arrivalRates meanServiceTimes
+    avgeTimesInQueue         = avgeTimeInQueue  arrivalRates meanServiceTimes
+
+    in map (\id -> OperatorInfo id (arrivalRates             ! id)
+                                   (meanServiceTimes         ! id)
+                                   (utilisations             ! id)
+                                   (stability                ! id)
+                                   (avgeNumberOfCustInSystem ! id)
+                                   (avgeResponseTimes        ! id)
+                                   (avgeTimesInQueue         ! id))
+           [1.. (snd $ bounds arrivalRates)]
+                              
 taxiQ1Calc:: [OperatorInfo]
 taxiQ1Calc = calcAll taxiQ1Array taxiQ1Inputs 1.2 taxiQ1meanServiceTimes
 

--- a/src/Striot/Jackson.hs
+++ b/src/Striot/Jackson.hs
@@ -150,28 +150,29 @@ Node, InputFrom, Input Rate, Selectivity, Output Rate
 This is represented as follows:      
 -}
        
-taxiQ1Array:: Array (Int,Int) Double
-taxiQ1Array = listArray ((1,1),(6,6)) $
+taxiQ1Array :: Array (Int,Int) Double
+taxiQ1Array  = listArray ((1,1),(7,7)) $
               -- Output Node
-              --  1    2    3    4    5     6
-               [  0   ,1   ,0   ,0   ,0    ,0  ,     -- node 1 streamMap
-                  0   ,0   ,0.95,0   ,0    ,0  ,     -- node 2 streamFilter
-                  0   ,0   ,0   ,1   ,0    ,0  ,     -- node 3 streamWindow
-                  0   ,0   ,0   ,0   ,1    ,0  ,     -- node 4 streamMap
-                  0   ,0   ,0   ,0   ,0    ,0.1,     -- node 5 streamFilterAcc
-                  0   ,0   ,0   ,0   ,0    ,0  ]     -- node 6 the output of Q1
+              --  0   ,1    2    3    4    5     6
+               [  0   ,1   ,0   ,0   ,0   ,0    ,0  ,     -- node 1 Source
+                  0   ,0   ,1   ,0   ,0   ,0    ,0  ,     -- node 2 streamMap
+                  0   ,0   ,0   ,0.95,0   ,0    ,0  ,     -- node 3 streamFilter
+                  0   ,0   ,0   ,0   ,1   ,0    ,0  ,     -- node 4 streamWindow
+                  0   ,0   ,0   ,0   ,0   ,1    ,0  ,     -- node 5 streamMap
+                  0   ,0   ,0   ,0   ,0   ,0    ,0.1,     -- node 6 streamFilterAcc
+                  0   ,0   ,0   ,0   ,0   ,0    ,0  ]     -- node 7 the output of Q1
 
  
-taxiQ1Inputs = listArray (1,6) $ [1,0,0,0,0,0] -- all events in the input stream are sent to node 1
+taxiQ1Inputs = listArray (1,7) $ [1,0,0,0,0,0,0] -- all events in the input stream are sent to node 1
 
 taxiQ1meanServiceTimes:: Array Int Double
-taxiQ1meanServiceTimes = listArray (1,6) [0.0001,0.0001,0.0001,0.01,0.0001,0.0001]
-
+taxiQ1meanServiceTimes = listArray (1,7) [0,0.0001,0.0001,0.0001,0.01,0.0001,0.0001]
  
 taxiQ1arrivalRates:: Array Int Double
 taxiQ1arrivalRates = arrivalRate taxiQ1Array taxiQ1Inputs 1.2 -- the 1.2 is the arrival rate (in events per second) into the system
 
-
+test_taxiQ1arrivalRates = assertEqual taxiQ1arrivalRates $
+    array (1,7) [(1,1.2),(2,1.2),(3,1.2),(4,1.14),(5,1.14),(6,1.14),(7,0.11399999999999999)]
 
 taxiQ1utilisation = utilisation taxiQ1arrivalRates taxiQ1meanServiceTimes 
 
@@ -211,7 +212,6 @@ calcAll connections arrivalRates meanServiceTimes = let
                               
 taxiQ1Calc:: [OperatorInfo]
 taxiQ1Calc = calcAll taxiQ1Array (arrivalRate taxiQ1Array taxiQ1Inputs 1.2) taxiQ1meanServiceTimes
-
 
 -- basic tests
 ex1   = listArray ((1,1),(3,3)) $ [1,0,0,-0.5,1,0,-0.5,0,1]                    

--- a/src/Striot/Jackson.hs
+++ b/src/Striot/Jackson.hs
@@ -56,8 +56,11 @@ arrivalRate:: Array (Int, Int) Double -> Array Int Double -> Double -> Array Int
 -- p - selectivities of filters
 -- p0i - distribution of input events into the system (i.e. to which nodes, which are the source nodes)
 -- alpha- arrival rate into the system
-arrivalRate p p0i alpha =  mv_mult (inverse $ mm_subtract (identity p) (m_trans p)) aa
-                               where aa = va_mult p0i alpha
+arrivalRate p p0i alpha = arrivalRate' p aa
+                              where aa = va_mult p0i alpha
+
+arrivalRate' p aa = mv_mult (inverse $ mm_subtract (identity p) (m_trans p)) aa
+ 
   
 -- ρ = λ/μ is the utilization of the buffer (the average proportion of time which the server is occupied.  
 utilisation:: Array Int Double -> Array Int Double -> Array Int Double
@@ -160,11 +163,10 @@ data OperatorInfo = OperatorInfo { opId        :: Int
                                  , respTime    :: Double
                                  , queueTime   :: Double
                                  }
-                                 deriving (Show)
+                                 deriving (Show,Eq)
                                  
-calcAll:: Array (Int,Int) Double -> Array Int Double -> Double -> Array Int Double -> [OperatorInfo]
-calcAll connections inputs alpha meanServiceTimes = let
-    arrivalRates             = arrivalRate connections inputs alpha
+calcAll:: Array (Int,Int) Double -> Array Int Double -> Array Int Double -> [OperatorInfo]
+calcAll connections arrivalRates meanServiceTimes = let
     utilisations             = utilisation arrivalRates meanServiceTimes
     stability                = stable arrivalRates meanServiceTimes
     avgeNumberOfCustInSystem = avgeNumberOfCustomersInSystem utilisations
@@ -181,7 +183,7 @@ calcAll connections inputs alpha meanServiceTimes = let
            [1.. (snd $ bounds arrivalRates)]
                               
 taxiQ1Calc:: [OperatorInfo]
-taxiQ1Calc = calcAll taxiQ1Array taxiQ1Inputs 1.2 taxiQ1meanServiceTimes
+taxiQ1Calc = calcAll taxiQ1Array (arrivalRate taxiQ1Array taxiQ1Inputs 1.2) taxiQ1meanServiceTimes
 
 
 -- basic tests

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -5,6 +5,9 @@ module Striot.LogicalOptimiser ( applyRules
                                , costModel
                                , optimise
 
+                               , firstMatch
+                               , filterMerge
+
                                , htf_thisModulesTests
                                ) where
 

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -104,7 +104,7 @@ filterFuse _ = Nothing
 gt3 = [| (>3) |]
 lt5 = [| (<5) |]
 
-so' = StreamVertex 0 Source       []    "String" "String" 1
+so' = StreamVertex 0 (Source 1)   []    "String" "String" 1
 f3  = StreamVertex 1 (Filter 0.5) [gt3] "String" "String" 1
 f4  = StreamVertex 2 (Filter 0.5) [lt5] "String" "String" 1
 si' = StreamVertex 3 Sink         []    "String" "String" 1
@@ -138,7 +138,7 @@ f1 = StreamVertex 2 (Filter 0.5) [[| \x -> length x <3 |]] "String" "String" 1
 f2 = StreamVertex 1 (Filter 0.5) [[| (\x -> length x <3) . (show) |]] "Int" "Int" 2
 m2 = StreamVertex 2 Map [[| show |]] "Int" "String" 1
 
-so = StreamVertex 0 Source [] "Int" "Int" 1
+so = StreamVertex 0 (Source 1) [] "Int" "Int" 1
 si = StreamVertex 3 Sink [] "String" "String" 1
 
 mapFilterPre  = path [ so, m1, f1, si ]
@@ -178,7 +178,7 @@ filterFilterAcc (Connect (Vertex v1@(StreamVertex i (Filter sel1) (p:_) ty _ s1)
 filterFilterAcc _ = Nothing
 
 filterFilterAccPre = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 (Filter 0.5) [p] "Int" "Int" 1
     , StreamVertex 2 (FilterAcc 0.5) [f , a , q] "Int" "Int" 1
     , StreamVertex 3 Sink [] "Int" "Int" 1
@@ -189,7 +189,7 @@ filterFilterAccPre = path
           q = [| \new (b,old) -> b || old /= new |]
 
 filterFilterAccPost = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 (FilterAcc 0.25)
         [ [| \a v -> if $(p) v then $(f) a v else a |]
         , a
@@ -216,7 +216,7 @@ filterAccFilter (Connect (Vertex v1@(StreamVertex i (FilterAcc sel1) (f:a:p:_) t
 filterAccFilter _ = Nothing
 
 filterAccFilterPre = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 (FilterAcc 0.5) [f,a,p] "Int" "Int" 1
     , StreamVertex 2 (Filter 0.5)    [q] "Int" "Int" 1
     , StreamVertex 3 Sink [] "Int" "Int" 1
@@ -227,7 +227,7 @@ filterAccFilterPre = path
           q = [| (>3) |]
 
 filterAccFilterPost = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 (FilterAcc 0.25) [f, a, p'] "Int" "Int" 2
     , StreamVertex 3 Sink [] "Int" "Int" 1
     ]
@@ -255,7 +255,7 @@ filterAccFilterAcc (Connect (Vertex v1@(StreamVertex i (FilterAcc sel1) (f:a:p:s
 filterAccFilterAcc _ = Nothing
 
 filterAccFilterAccPre = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 (FilterAcc 0.5) [f,a,p] "Int" "Int" 1
     , StreamVertex 2 (FilterAcc 0.5) [g,b,q] "Int" "Int" 1
     , StreamVertex 3 Sink [] "Int" "Int" 1
@@ -271,7 +271,7 @@ filterAccFilterAccPre = path
         q = [| (>=) |]
 
 filterAccFilterAccPost = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 (FilterAcc 0.25)
         [ [| \(a,b) v -> ($(f) a v, if $(p) v a then $(g) b v else b) |]
         , [| ($(a),$(b)) |]
@@ -299,14 +299,14 @@ mapFuse (Connect (Vertex v1@(StreamVertex i Map (f:ss) t1 _ s1))
 mapFuse _ = Nothing
 
 mapFusePre = path
-    [ StreamVertex 0 Source [] "String" "String" 1
+    [ StreamVertex 0 (Source 1) [] "String" "String" 1
     , StreamVertex 1 Map [[| show |]] "Int" "String" 1
     , StreamVertex 2 Map [[| length |]] "String" "Int" 1
     , StreamVertex 3 Sink [] "Int" "Int" 1
     ]
 
 mapFusePost = path
-    [ StreamVertex 0 Source [] "String" "String" 1
+    [ StreamVertex 0 (Source 1) [] "String" "String" 1
     , StreamVertex 1 Map [[| show >>> length |]] "Int" "Int" 2
     , StreamVertex 3 Sink [] "Int" "Int" 1
     ]
@@ -322,7 +322,7 @@ mapScan (Connect (Vertex v1@(StreamVertex i Map (f:ss) t1 _ s1))
 mapScan _ = Nothing
 
 mapScanPre = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 Map [f] "Int" "Int" 1
     , StreamVertex 2 Scan [g,a] "Int" "Int" 1
     , StreamVertex 3 Sink [] "Int" "Int" 1
@@ -333,7 +333,7 @@ mapScanPre = path
         a = [| 0 |]
 
 mapScanPost = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 Scan [[| flip (flip $(f) >>> $(g))|], [| $(a) |]] "Int" "Int" 2
     , StreamVertex 3 Sink [] "Int" "Int" 1
     ]
@@ -357,7 +357,7 @@ expandFilter (Connect (Vertex e@(StreamVertex j Expand _ t1 t2 se))
 expandFilter _ = Nothing
 
 expandFilterPre = path
-    [ StreamVertex 0 Source       [] "[Int]" "[Int]" 1
+    [ StreamVertex 0 (Source 1)       [] "[Int]" "[Int]" 1
     , StreamVertex 1 Expand       [] "[Int]" "Int" 2
     , StreamVertex 2 (Filter 0.5) [[|$(p)|]] "Int" "Int" 3
     , StreamVertex 3 Sink         [] "Int" "Int" 4
@@ -366,7 +366,7 @@ expandFilterPre = path
         p = [| (>3) |]
 
 expandFilterPost = path
-    [ StreamVertex 0 Source [] "[Int]" "[Int]" 1
+    [ StreamVertex 0 (Source 1) [] "[Int]" "[Int]" 1
     , StreamVertex 1 Map [[|filter $(p) |]] "[Int]" "[Int]" 3
     , StreamVertex 2 Expand [] "[Int]" "Int" 2
     , StreamVertex 3 Sink [] "Int" "Int" 4
@@ -389,7 +389,7 @@ mapFilterAcc (Connect (Vertex m@(StreamVertex i Map (f:_) t1 _ sm))
 mapFilterAcc _ = Nothing
 
 mapFilterAccPre = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 Map [f] "Int" "String" 1
     , StreamVertex 2 (FilterAcc 0.5) [g,a,p] "String" "String" 1
     , StreamVertex 3 Sink [] "String" "String" 1
@@ -401,7 +401,7 @@ mapFilterAccPre = path
         p = [| \new (b,old) -> b || old /= new |]
 
 mapFilterAccPost = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 (FilterAcc 0.5) [g,a, [| $(f) >>> $(p) |]] "Int" "Int" 2
     , StreamVertex 2 Map [f] "Int" "String" 1
     , StreamVertex 3 Sink [] "String" "String" 1
@@ -428,14 +428,14 @@ mapWindow (Connect (Vertex m@(StreamVertex i Map (f:_) t1 _ sm))
 mapWindow _ = Nothing
 
 mapWindowPre = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 Map    [[| show |]] "Int" "String" 2
     , StreamVertex 2 Window [[| chop 2 |]] "String" "[String]" 3
     , StreamVertex 3 Sink   [] "[String]" "[String]" 4
     ]
 
 mapWindowPost = path
-    [ StreamVertex 0 Source [] "Int" "Int" 1
+    [ StreamVertex 0 (Source 1) [] "Int" "Int" 1
     , StreamVertex 1 Window [[| chop 2 |]] "Int" "[Int]" 3
     , StreamVertex 2 Map    [[| map show |]] "[Int]" "[String]" 2
     , StreamVertex 3 Sink   [] "[String]" "[String]" 4
@@ -458,14 +458,14 @@ expandMap (Connect (Vertex e@(StreamVertex i Expand _ t1 _ se))
 expandMap _ = Nothing
 
 expandMapPre = path
-    [ StreamVertex 0 Source [] "[Int]" "[Int]" 1
+    [ StreamVertex 0 (Source 1) [] "[Int]" "[Int]" 1
     , StreamVertex 1 Expand [] "[Int]" "Int" 2
     , StreamVertex 2 Map [[| show |]] "Int" "String" 3
     , StreamVertex 3 Sink [] "String" "String" 4
     ]
 
 expandMapPost = path
-    [ StreamVertex 0 Source [] "[Int]" "[Int]" 1
+    [ StreamVertex 0 (Source 1) [] "[Int]" "[Int]" 1
     , StreamVertex 1 Map [[| map (show) |]] "[Int]" "[String]" 3
     , StreamVertex 2 Expand [] "[String]" "String" 2
     , StreamVertex 3 Sink [] "String" "String" 4
@@ -499,7 +499,7 @@ expandScan (Connect (Vertex  e@(StreamVertex i Expand (_)     t1 t2 se))
 expandScan _ = Nothing
 
 expandScanPre = path
-    [ StreamVertex 0 Source []    "[Int]" "[Int]" 1
+    [ StreamVertex 0 (Source 1) []    "[Int]" "[Int]" 1
     , StreamVertex 1 Expand []    "[Int]" "Int" 2
     , StreamVertex 2 Scan   [f,a] "Int"   "Int" 3
     , StreamVertex 3 Sink   []    "Int"   "Int" 4
@@ -509,7 +509,7 @@ expandScanPre = path
         a = [| 0 |]
 
 expandScanPost = path
-    [ StreamVertex 0 Source       []     "[Int]" "[Int]" 1
+    [ StreamVertex 0 (Source 1)       []     "[Int]" "[Int]" 1
     , StreamVertex 1 (Filter 0.5) [p]    "[Int]" "[Int]" 0
     , StreamVertex 2 Scan         [g,as] "[Int]" "[Int]" 3
     , StreamVertex 4 Expand       []     "[Int]" "Int" 2
@@ -536,14 +536,14 @@ expandExpand (Connect (Vertex e@(StreamVertex i Expand _ t1 t2 s))
 expandExpand _ = Nothing
 
 expandExpandPre = path
-    [ StreamVertex 0 Source [] "[Int]" "[Int]" 1
+    [ StreamVertex 0 (Source 1) [] "[Int]" "[Int]" 1
     , StreamVertex 1 Expand [] "[[Int]]" "[Int]" 2
     , StreamVertex 2 Expand [] "[Int]" "Int" 3
     , StreamVertex 3 Sink   [] "Int" "[Int]" 4
     ]
 
 expandExpandPost = path
-    [ StreamVertex 0 Source [] "[Int]" "[Int]" 1
+    [ StreamVertex 0 (Source 1) [] "[Int]" "[Int]" 1
     , StreamVertex 1 Map [[| concat |]] "[[Int]]" "[Int]" 2
     , StreamVertex 2 Expand [] "[Int]" "Int" 3
     , StreamVertex 3 Sink   [] "Int" "[Int]" 4
@@ -587,8 +587,8 @@ hoistOp op (Connect (Vertex m@(StreamVertex i Merge _ _ ty _))
 
 hoistOp _ _ = Nothing
 
-v1 = StreamVertex 0 Source       []           "Int" "Int" 1
-v2 = StreamVertex 1 Source       []           "Int" "Int" 2
+v1 = StreamVertex 0 (Source 1)       []           "Int" "Int" 1
+v2 = StreamVertex 1 (Source 1)       []           "Int" "Int" 2
 v3 = StreamVertex 2 Merge        []           "Int" "Int" 3
 v4 = StreamVertex 3 (Filter 0.5) [[| (>3) |]] "Int" "Int" 4
 v5 = StreamVertex 4 Sink         []           "Int" "Int" 5
@@ -609,8 +609,8 @@ test_mergeFilter = assertEqual (applyRule mergeFilter mergeFilterPre)
 mergeExpand :: RewriteRule
 mergeExpand = hoistOp Expand
 
-v8  = StreamVertex 0 Source [] "[Int]" "[Int]" 1
-v9  = StreamVertex 1 Source [] "[Int]" "[Int]" 2
+v8  = StreamVertex 0 (Source 1) [] "[Int]" "[Int]" 1
+v9  = StreamVertex 1 (Source 1) [] "[Int]" "[Int]" 2
 v10 = StreamVertex 2 Merge  [] "[Int]" "[Int]" 3
 v11 = StreamVertex 3 Expand [] "[Int]" "Int"   4
 
@@ -631,8 +631,8 @@ test_mergeExpand = assertEqual (applyRule mergeExpand mergeExpandPre)
 mergeMap :: RewriteRule
 mergeMap = hoistOp Map
 
-v15 = StreamVertex 0 Source [] "Int" "Int" 1
-v16 = StreamVertex 1 Source [] "Int" "Int" 2
+v15 = StreamVertex 0 (Source 1) [] "Int" "Int" 1
+v16 = StreamVertex 1 (Source 1) [] "Int" "Int" 2
 v17 = StreamVertex 2 Merge []  "Int" "Int" 3
 v18 = StreamVertex 3 Map [[| show |]]  "Int" "String" 4
 v19 = StreamVertex 4 Sink [] "String" "String" 5
@@ -736,9 +736,9 @@ mergeFuse (Connect (Vertex m1@(StreamVertex i Merge _ _ _ _))
 
 mergeFuse _ = Nothing
 
-v23 = StreamVertex 0 Source [] "Int" "Int" 1
-v24 = StreamVertex 1 Source [] "Int" "Int" 2
-v25 = StreamVertex 2 Source [] "Int" "Int" 3
+v23 = StreamVertex 0 (Source 1) [] "Int" "Int" 1
+v24 = StreamVertex 1 (Source 1) [] "Int" "Int" 2
+v25 = StreamVertex 2 (Source 1) [] "Int" "Int" 3
 v26 = StreamVertex 3 Merge []  "Int" "Int" 4
 v27 = StreamVertex 4 Merge []  "Int" "Int" 5
 v28 = StreamVertex 5 Sink []   "Int" "Int" 6

--- a/src/Striot/StreamGraph.hs
+++ b/src/Striot/StreamGraph.hs
@@ -34,6 +34,7 @@ data StreamVertex = StreamVertex
     , parameters :: [ExpQ]
     , intype     :: String
     , outtype    :: String
+    , serviceTime:: Double
     }
 
 instance Eq StreamVertex where
@@ -45,13 +46,14 @@ instance Eq StreamVertex where
                  ]
 
 instance Show StreamVertex where
-    show (StreamVertex i o ps inT outT) =
+    show (StreamVertex i o ps inT outT s) =
         "StreamVertex " ++ intercalate " "
             [ show i
             , show o
             , show (map showParam ps)
             , show inT
             , show outT
+            , show s
             ]
 
 deQ :: Q Exp -> Exp
@@ -96,16 +98,17 @@ instance Ord StreamVertex where
 -- quickcheck experiment
 
 instance Arbitrary StreamOperator where
-    arbitrary = elements [ Map , Filter , Expand , Window , Merge , Join , Scan
-                         , FilterAcc , Source , Sink ]
+    arbitrary = elements [ Map , Filter, Expand , Window , Merge , Join , Scan
+                         , FilterAcc, Source , Sink ]
 
 instance Arbitrary StreamVertex where
     arbitrary = do
         vertexId <- arbitrary
         operator <- arbitrary
+        serviceT <- arbitrary
         let parameters = []
             ty = "String" in
-            return $ StreamVertex vertexId operator parameters ty ty
+            return $ StreamVertex vertexId operator parameters ty ty serviceT
 
 streamgraph :: Gen StreamGraph
 streamgraph = sized streamgraph'

--- a/src/Striot/StreamGraph.hs
+++ b/src/Striot/StreamGraph.hs
@@ -80,13 +80,13 @@ type PartitionedGraph = ([StreamGraph], StreamGraph)
 -- |An enumeration of the possible stream operators within a stream-processing program,
 -- as well as `Source` and `Sink` to represent the ingress and egress points of programs.
 data StreamOperator = Map
-                    | Filter
+                    | Filter Double -- selectivity
                     | Expand
                     | Window
                     | Merge
                     | Join
                     | Scan
-                    | FilterAcc
+                    | FilterAcc Double -- selectivity
                     | Source
                     | Sink
                     deriving (Show,Ord,Eq)
@@ -98,8 +98,10 @@ instance Ord StreamVertex where
 -- quickcheck experiment
 
 instance Arbitrary StreamOperator where
-    arbitrary = elements [ Map , Filter, Expand , Window , Merge , Join , Scan
-                         , FilterAcc, Source , Sink ]
+    arbitrary = do
+        d <- arbitrary
+        elements [ Map , Filter d, Expand , Window , Merge , Join , Scan
+                       , FilterAcc d, Source , Sink ]
 
 instance Arbitrary StreamVertex where
     arbitrary = do

--- a/src/Striot/StreamGraph.hs
+++ b/src/Striot/StreamGraph.hs
@@ -9,6 +9,7 @@ module Striot.StreamGraph ( StreamGraph(..)
                           , StreamVertex(..)
                           , PartitionedGraph(..)
                           , deQ
+                          , isSource
                           , showParam
                           ) where
 
@@ -87,12 +88,16 @@ data StreamOperator = Map
                     | Join
                     | Scan
                     | FilterAcc Double -- selectivity
-                    | Source
+                    | Source Double -- arrival rate
                     | Sink
                     deriving (Show,Ord,Eq)
 
 instance Ord StreamVertex where
     compare x y = compare (vertexId x) (vertexId y)
+
+isSource :: StreamOperator -> Bool
+isSource (Source _) = True
+isSource _ = False
 
 ------------------------------------------------------------------------------
 -- quickcheck experiment
@@ -101,7 +106,7 @@ instance Arbitrary StreamOperator where
     arbitrary = do
         d <- arbitrary
         elements [ Map , Filter d, Expand , Window , Merge , Join , Scan
-                       , FilterAcc d, Source , Sink ]
+                       , FilterAcc d, Source d, Sink ]
 
 instance Arbitrary StreamVertex where
     arbitrary = do

--- a/src/Striot/VizGraph.hs
+++ b/src/Striot/VizGraph.hs
@@ -64,16 +64,16 @@ source x = [| do
     return x'
     |]
 
-v1 = StreamVertex 1 Source [source "foo"]    "String" "String" 0
+v1 = StreamVertex 1 (Source 1) [source "foo"]    "String" "String" 0
 v2 = StreamVertex 2 Map    [[| id |]]        "String" "String" 1
-v3 = StreamVertex 3 Source [source "bar"]    "String" "String" 2
+v3 = StreamVertex 3 (Source 1) [source "bar"]    "String" "String" 2
 v4 = StreamVertex 4 Map    [[| id |]]        "String" "String" 3
 v5 = StreamVertex 5 Merge  []                "[String]" "String" 4
 v6 = StreamVertex 6 Sink   [[| mapM_ print|]] "String" "IO ()" 5
 mergeEx :: StreamGraph
 mergeEx = overlay (path [v3, v4, v5]) (path [v1, v2, v5, v6])
 
-v7 = StreamVertex  1 Source [[| sourceOfRandomTweets |]] "String" "String" 0
+v7 = StreamVertex  1 (Source 1) [[| sourceOfRandomTweets |]] "String" "String" 0
 v8 = StreamVertex  2 Map    [[| filter (('#'==).head) . words |]] "String" "[String]" 1
 v9 = StreamVertex  5 Expand [] "[String]" "String" 2
 v10 = StreamVertex 6 Sink   [[|mapM_ print|]] "String" "IO ()" 3

--- a/src/Striot/VizGraph.hs
+++ b/src/Striot/VizGraph.hs
@@ -27,7 +27,10 @@ show' :: StreamVertex -> String
 show' v = intercalate " " $ ((printOp . operator) v) : ((map (\s->"("++s++")")) . map showParam . parameters) v
 
 printOp :: StreamOperator -> String
-printOp = (++) "stream" . show
+printOp (Filter _)        = "streamFilter"
+printOp (FilterAcc _)     = "streamFilterAcc"
+printOp (Source _)        = "streamSource"
+printOp x                 = "stream" ++ (show x)
 
 myStyle :: Style StreamVertex String
 myStyle = Style

--- a/src/Striot/VizGraph.hs
+++ b/src/Striot/VizGraph.hs
@@ -61,19 +61,19 @@ source x = [| do
     return x'
     |]
 
-v1 = StreamVertex 1 Source [source "foo"]    "String" "String"
-v2 = StreamVertex 2 Map    [[| id |]]        "String" "String"
-v3 = StreamVertex 3 Source [source "bar"]    "String" "String"
-v4 = StreamVertex 4 Map    [[| id |]]        "String" "String"
-v5 = StreamVertex 5 Merge  []                "[String]" "String"
-v6 = StreamVertex 6 Sink   [[| mapM_ print|]] "String" "IO ()"
+v1 = StreamVertex 1 Source [source "foo"]    "String" "String" 0
+v2 = StreamVertex 2 Map    [[| id |]]        "String" "String" 1
+v3 = StreamVertex 3 Source [source "bar"]    "String" "String" 2
+v4 = StreamVertex 4 Map    [[| id |]]        "String" "String" 3
+v5 = StreamVertex 5 Merge  []                "[String]" "String" 4
+v6 = StreamVertex 6 Sink   [[| mapM_ print|]] "String" "IO ()" 5
 mergeEx :: StreamGraph
 mergeEx = overlay (path [v3, v4, v5]) (path [v1, v2, v5, v6])
 
-v7 = StreamVertex  1 Source [[| sourceOfRandomTweets |]] "String" "String"
-v8 = StreamVertex  2 Map    [[| filter (('#'==).head) . words |]] "String" "[String]"
-v9 = StreamVertex  5 Expand [] "[String]" "String"
-v10 = StreamVertex 6 Sink   [[|mapM_ print|]] "String" "IO ()"
+v7 = StreamVertex  1 Source [[| sourceOfRandomTweets |]] "String" "String" 0
+v8 = StreamVertex  2 Map    [[| filter (('#'==).head) . words |]] "String" "[String]" 1
+v9 = StreamVertex  5 Expand [] "[String]" "String" 2
+v10 = StreamVertex 6 Sink   [[|mapM_ print|]] "String" "IO ()" 3
 expandEx :: StreamGraph
 expandEx = path [v7, v8, v9, v10]
 

--- a/src/Striot/VizGraph.hs
+++ b/src/Striot/VizGraph.hs
@@ -3,6 +3,7 @@
 
 module Striot.VizGraph ( streamGraphToDot
                        , displayGraph
+                       , displayGraphKitty
                        , htf_thisModulesTests) where
 
 import Striot.StreamGraph
@@ -11,10 +12,11 @@ import Algebra.Graph.Export.Dot
 import Data.String
 import Test.Framework
 import Data.List (intercalate)
+import Data.List.Split
 import Language.Haskell.TH
 
 import System.Process
-import System.IO (openTempFile, hPutStr, hClose)
+import System.IO (openTempFile, hPutStr, hGetContents, hClose)
 
 streamGraphToDot :: StreamGraph -> String
 streamGraphToDot = export myStyle
@@ -81,3 +83,17 @@ displayGraph g = do
 
     hPutStr hin (streamGraphToDot g)
     hClose hin
+
+displayGraphKitty :: StreamGraph -> IO ()
+displayGraphKitty g = do
+    (Just hin, Just hout, _, _)   <- createProcess (proc "dot" ["-Tpng"])
+      { std_out = CreatePipe, std_in = CreatePipe }
+    (_, Just hout2, _, _) <- createProcess (proc "base64" ["-w0"])
+      { std_in = UseHandle hout , std_out = CreatePipe }
+
+    hPutStr hin (streamGraphToDot g)
+    hClose hin
+    foo <- hGetContents hout2
+    let bar = chunksOf 4096 foo
+    mapM_ (\c -> putStr $ "\ESC_Gf=100,a=T,m=1;" ++ c ++ "\ESC\\") (init bar)
+    putStrLn $ "\ESC_Gf=100,a=T,m=0;" ++ (last bar) ++ "\ESC\\"

--- a/src/Striot/VizGraph.hs
+++ b/src/Striot/VizGraph.hs
@@ -4,6 +4,8 @@
 module Striot.VizGraph ( streamGraphToDot
                        , displayGraph
                        , displayGraphKitty
+                       , displayGraphDebug
+
                        , htf_thisModulesTests) where
 
 import Striot.StreamGraph
@@ -75,15 +77,19 @@ v10 = StreamVertex 6 Sink   [[|mapM_ print|]] "String" "IO ()"
 expandEx :: StreamGraph
 expandEx = path [v7, v8, v9, v10]
 
+-- | display a graph using GraphViz and "display" from ImageMagick
 displayGraph :: StreamGraph -> IO ()
-displayGraph g = do
+displayGraph = displayGraph' streamGraphToDot
+
+displayGraph' toDot g = do
     (Just hin,Just hout,_, _) <- createProcess (proc "dot" ["-Tpng"])
       { std_out = CreatePipe, std_in = CreatePipe }
     _ <- createProcess (proc "display" []){ std_in = UseHandle hout }
 
-    hPutStr hin (streamGraphToDot g)
+    hPutStr hin (toDot g)
     hClose hin
 
+-- | display a graph inline in the Kitty terminal emulator
 displayGraphKitty :: StreamGraph -> IO ()
 displayGraphKitty g = do
     (Just hin, Just hout, _, _)   <- createProcess (proc "dot" ["-Tpng"])
@@ -97,3 +103,7 @@ displayGraphKitty g = do
     let bar = chunksOf 4096 foo
     mapM_ (\c -> putStr $ "\ESC_Gf=100,a=T,m=1;" ++ c ++ "\ESC\\") (init bar)
     putStrLn $ "\ESC_Gf=100,a=T,m=0;" ++ (last bar) ++ "\ESC\\"
+
+-- | display a debug graph using GraphViz and ImageMagick
+displayGraphDebug = displayGraph' (export debugStyle :: StreamGraph -> String)
+debugStyle        = myStyle { vertexAttributes = (\v -> ["label":=(escape . show) v]) }

--- a/src/TestMain.hs
+++ b/src/TestMain.hs
@@ -12,4 +12,6 @@ import Striot.Nodes
 
 import {-@ HTF_TESTS @-} Striot.LogicalOptimiser
 
+import {-@ HTF_TESTS @-} Striot.Jackson
+
 main = htfMain htf_importedTests

--- a/striot.cabal
+++ b/striot.cabal
@@ -27,6 +27,7 @@ library
                       Striot.CompileIoT
                       Striot.StreamGraph
                       Striot.VizGraph
+                      Striot.Jackson
   -- other-modules:
   -- other-extensions:
   build-depends:      base              >= 4.9
@@ -56,6 +57,8 @@ library
                     , utility-ht        >= 0.0.14
                     , template-haskell  >= 2.14.0
                     , syb
+                    , dsp               >= 0.2
+                    , array             >= 0.5
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -90,6 +93,8 @@ test-suite test-striot
                     , utility-ht        >= 0.0.14
                     , template-haskell  >= 2.14.0
                     , syb
+                    , dsp               >= 0.2
+                    , array             >= 0.5
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing
@@ -101,4 +106,5 @@ test-suite test-striot
                       Striot.Nodes.MQTT
                       Striot.StreamGraph
                       Striot.VizGraph
+                      Striot.Jackson
   default-language:   Haskell2010


### PR DESCRIPTION
(This is based on top of #114)

Introduce Jackson network parameters to the StreamGraph and StreamOperator types: mean service times for all operators (in the StreamGraph type); selectivities for filters (in the StreamOperator type); arrival rates for source nodes (in the StreamOperator type).

Update all instances of those types in all tests and examples.

Add Jackson calculation (from Paul) and bridging code to convert StreamGraphs to Matrices for running through those calculations (both in Jackson.hs)

New example OverUt.hs demonstrates how all this can be used to catch overutilisation introduced by a rewrite.

I've rebased this over and over to get it down to 23 commits and to remove any side-tracks or false-starts, and to make reviewing as easy as possible (even though it's still a large merge). The 23 commits are logically distinct which might help review it in portions.