### PR TITLE
StreamGraph: Better Gen instance via Tree

### DIFF
--- a/src/TestMain.hs
+++ b/src/TestMain.hs
@@ -3,6 +3,9 @@
 module Main where
 
 import Test.Framework
+
+import {-@ HTF_TESTS @-} Striot.StreamGraph
+
 import {-@ HTF_TESTS @-} Striot.CompileIoT
 import {-@ HTF_TESTS @-} Striot.VizGraph
 


### PR DESCRIPTION
Write a module-private Gen function for a type "Tree StreamVertex",
then use this as the basis for the Arbitrary StreamGraph instance.

I noticed whilst writing some of Partition.hs that it was easier to
reason about the stream-processing programs as a Tree than as a
Graph StreamVertex. (My first few implementations of that algorithm
were actually in terms of a Tree type, and I transcribed it over to
StreamGraph when finished).

The generator functions for Tree StreamVertex work backwards from the
Sink root-node, and abide by the following rules:

 * Operator valences are correct. Exactly two incoming edges to a
   Join. One or more incoming edges to a Merge. Zero incoming edges
   to a Source. Exactly one incoming edge to any other operator.
 * Expand cannot follow Join (type error)
 * vertexIds are unique to each Operator instance

There are several limitations to generated graphs, which could
potentially be addressed in future:

 * asides from the example above, there is no consideration of Types,
   and several type errors are possible (especially concerning Merge)
 * Merges have either one or two incoming streams, never more

However it's much better than the previous generator which created
graphs with cycles amongst other defects.