### PR TITLE
WIP: Initial separate builder/runner images

### DIFF
--- a/containers/Makefile
+++ b/containers/Makefile
@@ -9,7 +9,6 @@ src_dir := $(base)/src
 in_srcs := $(wildcard ../src/*.hs) $(wildcard ../src/**/*.hs) $(wildcard ../src/**/**/*.hs)
 out_srcs := $(subst ..,$(base),$(in_srcs))
 
-.PHONY: all
 all: $(cabal) $(license) $(readme) $(out_srcs)
 	@echo "Building image $(prefix)/striot-base"
 	@docker build -t $(prefix)/striot-base striot-base
@@ -29,10 +28,14 @@ $(readme): $(src_dir) ../README.md
 $(src_dir):
 	@mkdir -p $(src_dir)
 
-.PHONY: clean
+runtime:
+	@docker build -t $(prefix)/striot-runtime runtime
+
 clean:
 	@echo "Removing striot-base/striot"
 	@rm -rf striot-base/striot
 	@if [ -n "$$(docker images -q $(prefix)/striot-base)" ]; then \
 		docker rmi $(prefix)/striot-base; \
 	fi
+
+.PHONY: clean all runtime

--- a/containers/runtime/Dockerfile
+++ b/containers/runtime/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:10-slim
+WORKDIR /opt/node
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y librdkafka1 \
+    && apt-get clean
+USER nobody

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -395,13 +395,16 @@ test_reform_s1_2 = assertEqual s1 (unPartition $ createPartitions s1 [[0],[1,2]]
 
 genDockerfile listen opts = 
     let pkgs = packages opts in concat
-    [ "FROM striot/striot-base:latest\n"
+    [ "FROM striot/striot-base:latest as builder\n"
     , "WORKDIR /opt/node\n"
     , "COPY . /opt/node\n"
     , if pkgs /= [] then "RUN cabal install " ++ (intercalate " " pkgs) else ""
-    , "\n"
     , "RUN ghc node.hs\n"
+    , "\n"
+    , "FROM striot/striot-runtime:latest\n"
+    , "COPY --from=builder /opt/node/node /opt/node/node\n"
     , if listen then "EXPOSE 9001\n" else ""
+    , "\n"
     , "CMD /opt/node/node\n"
     ]
 


### PR DESCRIPTION
Define a new container, striot/striot-runtime, intended to be used as
the basis for runtime containers. Based on Debian 10 slim (aka Buster,
the current stable version at the time of writing) with the additional
librdkafka1 installed.

Adjust the Dockerfile-generation code to use a multi-stage build, where
the build takes place in striot/striot-base, and the resulting "node"
binary copied over to a new container based on the runtime.

The resulting images are much smaller: striot/striot-base is 3.15GB
right now, and striot/striot-runtime would be about 93.5MB. The binaries
we build are typically around 50M, but could be reduced to about 33M if
we strip the debug symbols out.

striot-base is based on haskell:8.6, which is based on Debian "Stretch"
("oldstable", the release before the current stable). There could be ABI
incompatibilities between libc or librdkafka1 in the builder and runner
containers. We should harmonize on a common base version; possibly the
/next/ Debian stable release (bullseye), which is due very soon, once
there are hub.docker.com/_/haskell containers based on it. I've marked
this "WIP" for that reason. (We might also need to look at GHC version.
I think 8.6 is already "unsupported" in the containers)

Another reason this is WIP: it will break the Taxi example, since node1
requires "sorteddata.csv" in the container.
debian:stretch