### PR TITLE
Jackson graph to dot

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -12,3 +12,5 @@ extra-deps:
 - socks-0.6.1
 - hw-kafka-client-3.0.0
 - envy-2.0.0.0
+- git: https://github.com/snowleopard/alga.git
+  commit: 1623fae605503595ee331929157c61b5e5e0c1c7


### PR DESCRIPTION
Adds `jacksonGraphToDot` which is a vizgraph-generating function that adds Jackson/Queueing theory data onto the output.

We might want to sit on merging this until algebraic-graphs releases 0.7 or newer.

Depends on #141.