### PR TITLE
Add new github action workflows

### DIFF
--- a/.github/workflows/build.workflow.yml
+++ b/.github/workflows/build.workflow.yml
@@ -1,0 +1,69 @@
+name: Build and Test
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  cabal-build:
+    name: Cabal build
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ghc: ['8.6', '8.8', '8.10', '9.0']
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: ${{ matrix.ghc }}
+
+      - name: Install librdkafka
+        run: |
+          # install librdkafka-dev
+          wget -qO - https://packages.confluent.io/deb/5.3/archive.key | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/5.3 stable main"
+          sudo apt-get update && sudo apt-get install librdkafka-dev
+
+      - name: Install Haskell deps
+        run: |
+          cabal install happy alex HTF
+          cabal install c2hs
+          cabal install --lib --only-dependencies --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
+
+      - name: Build and test striot
+        run: |
+          cabal configure --enable-tests && cabal build && cabal test
+
+  stack-build:
+    name: Stack build (+ examples)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: '8.6'
+          enable-stack: true
+
+      - name: Install librdkafka
+        run: |
+          # install librdkafka-dev
+          wget -qO - https://packages.confluent.io/deb/5.3/archive.key | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/5.3 stable main"
+          sudo apt-get update && sudo apt-get install librdkafka-dev
+
+      - name: Install Haskell deps
+        run: |
+          stack install happy alex HTF
+          stack install c2hs
+          stack install --only-dependencies
+
+      - name: Build and test striot
+        run: |
+          stack build && stack install && stack test
+          
+      - name: Build examples
+        run: |
+          ./gen_test_makefile.sh > Makefile; make

--- a/.github/workflows/deploy.workflow.yml
+++ b/.github/workflows/deploy.workflow.yml
@@ -1,0 +1,21 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build container image
+        run: make -C containers/
+      
+      - name: Push container image
+        run: docker push striot/striot-base:latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StrIoT — functional stream processing for IoT
 
-[![Travis CI Build Status](https://travis-ci.com/striot/striot.svg?branch=main)](https://travis-ci.com/striot/striot)
+![GitHub Actions Workflow](https://github.com/striot/striot/actions/workflows/build.workflow.yml/badge.svg)
 
 **StrIoT** is a stream-processing engine for IoT workloads, implemented as a
 [Haskell](https://www.haskell.org) library. A user defines a stream-processing

--- a/striot.cabal
+++ b/striot.cabal
@@ -48,7 +48,7 @@ library
                     , store-streaming   >= 0.1.0
                     , async
                     , prometheus        >= 2.2.2
-                    , net-mqtt          >= 0.6.2.1
+                    , net-mqtt          >= 0.6.2.1 && <= 0.7.1.0
                     , text
                     , process
                     , deepseq
@@ -84,7 +84,7 @@ test-suite test-striot
                     , store-streaming   >= 0.1.0
                     , async
                     , prometheus        >= 2.2.2
-                    , net-mqtt          >= 0.6.2.1
+                    , net-mqtt          >= 0.6.2.1 && <= 0.7.1.0
                     , text
                     , process
                     , deepseq


### PR DESCRIPTION
Our CI/CD has stopped working as travis is now paid for. GitHub actions has been around for a while and seems appropriate to move to instead - quickly knocked up some test workflows to see if we can get it back up and running.