### PR TITLE
Clean up older Optimisation code

### DIFF
--- a/examples/filterAcc/generate.hs
+++ b/examples/filterAcc/generate.hs
@@ -7,9 +7,7 @@ import Striot.CompileIoT
 import Striot.StreamGraph
 import Algebra.Graph
 
-opts = defaultOpts { imports  = imports defaultOpts ++ ["System.Random"]
-                   , rewrite = False
-                   }
+opts = defaultOpts { imports  = imports defaultOpts ++ ["System.Random"] }
 
 source = [| do
     i <- getStdRandom (randomR (1,10)) :: IO Int

--- a/examples/pipeline/generate.hs
+++ b/examples/pipeline/generate.hs
@@ -7,8 +7,6 @@ import Striot.CompileIoT
 import Striot.StreamGraph
 import Algebra.Graph
 
-opts = defaultOpts { rewrite = False }
-
 graph = path
     [ StreamVertex 1 (Source 1) [[| do
             threadDelay (1000*1000)
@@ -21,4 +19,4 @@ graph = path
     , StreamVertex 6 Sink   [[| mapM_ print |]] "[String]" "IO ()" 0
     ]
 
-main = partitionGraph graph [[1,2],[3],[4,5,6]] opts
+main = partitionGraph graph [[1,2],[3],[4,5,6]] defaultOpts

--- a/examples/taxi/generate.hs
+++ b/examples/taxi/generate.hs
@@ -18,7 +18,6 @@ opts = GenerateOpts { imports = imports defaultOpts ++
                         ]
                     , packages = []
                     , preSource = Just "preSource"
-                    , rewrite = True
                     }
 source = [| getLine >>= return . stringsToTrip . splitOn "," |]
 

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -89,7 +89,6 @@ data GenerateOpts = GenerateOpts
   { imports     :: [String]     -- ^ list of import statements to add to generated files
   , packages    :: [String]     -- ^ list of Cabal packages to install within containers
   , preSource   :: Maybe String -- ^ code to run prior to starting 'nodeSource'
-  , rewrite     :: Bool         -- ^ Whether to apply the logical optimiser
   , maxNodeUtil :: Double       -- ^ The per-Partition utilisation limit
   }
 
@@ -104,7 +103,6 @@ defaultOpts = GenerateOpts
                   ]
   , packages    = []
   , preSource   = Nothing
-  , rewrite     = True
   , maxNodeUtil = 3.0 -- finger in the air
   }
 
@@ -114,8 +112,7 @@ defaultOpts = GenerateOpts
 generateCode :: GenerateOpts -> StreamGraph -> PartitionMap -> [String]
 generateCode opts sg pm = let
     (sgs,cuts)      = createPartitions sg (sort (map sort pm))
-    sgs'            = if rewrite opts then map optimise sgs else sgs
-    enumeratedParts = zip [1..] sgs'
+    enumeratedParts = zip [1..] sgs
     in map (generateCodeFromStreamGraph opts enumeratedParts cuts) enumeratedParts
 
 -- TODO: the sorting of the `PartitionMap` is a work-around for

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Striot.LogicalOptimiser ( applyRules
-                               , costModel
                                , optimise
 
                                , applyRule

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Striot.LogicalOptimiser ( applyRules
-                               , optimise
 
                                , applyRule
                                , firstMatch
@@ -65,11 +64,6 @@ firstMatch g f = case f g of
                                 Just f  -> Just f
                                 Nothing -> firstMatch b f
 
--- thoughts about cost model
--- higher is better
-costModel :: StreamGraph -> Int
-costModel = negate . length . vertexList
-
 -- N-bounded recursive rule traversal
 -- (caller may wish to apply 'nub')
 applyRules :: Int -> StreamGraph -> [StreamGraph]
@@ -78,17 +72,6 @@ applyRules n sg =
         else let
              sgs = map ((&) sg) $ mapMaybe (firstMatch sg) rules
              in    sg : sgs ++ (concatMap (applyRules (n-1)) sgs)
-
--- | Return an optimised version of the supplied StreamGraph, or the
--- graph itself if no better alternative is found.
-optimise :: StreamGraph -> StreamGraph
-optimise sg = let
-    base              = costModel sg
-    sgs               = nub $ applyRules 5 sg
-    (score,candidate) = maximum $ map (\g -> (costModel g, g) ) sgs
-    in if score > base
-       then candidate
-       else sg
 
 ------------------------------------------------------------------------------
 

--- a/src/Striot/Orchestration.hs
+++ b/src/Striot/Orchestration.hs
@@ -40,7 +40,7 @@ import Control.Arrow ((>>>))
 
 import Striot.CompileIoT
 import Striot.Jackson
-import Striot.LogicalOptimiser
+import Striot.LogicalOptimiser (applyRules)
 import Striot.Partition
 import Striot.StreamGraph
 import Striot.VizGraph

--- a/src/Striot/Orchestration.hs
+++ b/src/Striot/Orchestration.hs
@@ -120,10 +120,6 @@ sumUtility opts sg pm = let
                 partCost  = fromIntegral (length pm)
             in  Just (graphCost, partCost)
 
--- | fitness function for StreamGraphs. Is this a viable program?
-viableStreamGraph :: [OperatorInfo] -> Bool
-viableStreamGraph = not . isOverUtilised
-
 ------------------------------------------------------------------------------
 -- test program taken from examples/filter/generate.hs
 
@@ -152,7 +148,7 @@ tooMuch = simpleStream
     , (Sink,     [[| mapM_ print |]], "Int", 0)
     ]
 
-test_tooMuch_notviable = assertBool (not . viableStreamGraph . calcAllSg $ tooMuch)
+test_tooMuch_notviable = assertBool (isOverUtilised . calcAllSg $ tooMuch)
 
 main = htfMain htf_thisModulesTests
 


### PR DESCRIPTION
To help see the wood from the trees: these routines were used when
applying the Logical Optimiser to the result of partitioning, which
we did in the early days. Now, we have the Optimiser module to do
things properly.

I've also added explicit names to some module imports, which aided
tracing which routines were being used by the old and new approaches.