### PR TITLE
rename and improve cost model function

### DIFF
--- a/src/Striot/Orchestration.hs
+++ b/src/Striot/Orchestration.hs
@@ -52,7 +52,7 @@ type Plan = (StreamGraph, PartitionMap)
 -- | The Cost of a 'Plan' (lower is better).
 -- 'Nothing' represents a non-viable pairing. 'Maybe' n represents the cost
 -- n.
-type Cost = Maybe (Double, Double)
+type Cost = Maybe Int
 
 -- | Apply rewrite rules to the supplied 'StreamGraph' to possibly rewrite
 -- it; partition it when a generated 'PartitionMap'; generate and write out
@@ -116,9 +116,7 @@ sumUtility opts sg pm = let
     oi = calcAllSg sg
     in if   isOverUtilised oi || any (> maxNodeUtil opts) (totalNodeUtilisations oi pm)
        then Nothing
-       else let graphCost = sum . map util $ oi
-                partCost  = fromIntegral (length pm)
-            in  Just (graphCost, partCost)
+       else Just (length pm)
 
 ------------------------------------------------------------------------------
 -- test program taken from examples/filter/generate.hs

--- a/src/Striot/Orchestration.hs
+++ b/src/Striot/Orchestration.hs
@@ -20,7 +20,7 @@ module Striot.Orchestration ( Plan
                             , viableRewrites
                             , deriveRewritesAndPartitionings
                             , allPartitionsPaired
-                            , sumUtility
+                            , planCost
 
                             -- $fromCompileIoT
                             , simpleStream
@@ -80,12 +80,12 @@ chopAndChange opts sg = case viableRewrites opts sg of
 --   * for each pair of graph and partitioning ('Plan'):
 --
 --       * reject any pairings which are not viable
---       * 'Cost' the pairs with the cost model 'sumUtility'
+--       * 'Cost' the pairs with the cost model 'planCost'
 --
 --   * return the 'Plan' paired with with the 'Cost' from applying the cost model.
 viableRewrites :: GenerateOpts -> StreamGraph -> [(Plan, Cost)]
 viableRewrites opts = deriveRewritesAndPartitionings (rules opts)
-                  >>> map (toSnd (uncurry (sumUtility opts)))
+                  >>> map (toSnd (uncurry (planCost opts)))
                   >>> filter (isJust . snd)
 
 test_viableRewrites_graph = assertNotEmpty $ viableRewrites defaultOpts graph
@@ -111,8 +111,8 @@ allPartitionsPaired sg = map (\pm -> (sg,pm)) (allPartitions sg)
 -- 'Nothing' if the 'Plan' is not viable,
 -- either due to an over-utilised operator or an over-utilised 'Partition'.
 --
-sumUtility :: GenerateOpts -> StreamGraph -> PartitionMap -> Cost
-sumUtility opts sg pm = let
+planCost :: GenerateOpts -> StreamGraph -> PartitionMap -> Cost
+planCost opts sg pm = let
     oi = calcAllSg sg
     in if   isOverUtilised oi || any (> maxNodeUtil opts) (totalNodeUtilisations oi pm)
        then Nothing
@@ -186,7 +186,7 @@ test_overUtilisedPartition_minThreePartitions = assertBool $
     (not . any (<3) . map (length.snd.fst) . viableRewrites defaultOpts) partUtilGraph
 
 test_overUtilisedPartition_rejected = -- example of an over-utilised partition
-    assertNothing (sumUtility defaultOpts partUtilGraph [[1,2],[3,4,5,6,7,8,9]])
+    assertNothing (planCost defaultOpts partUtilGraph [[1,2],[3,4,5,6,7,8,9]])
 
 -- example of an acceptable PartitionMap
 test_overUtilisedPartition_acceptable = assertElem [[1,2,3],[4,5,6],[7,8,9]]

--- a/src/Striot/Orchestration.hs
+++ b/src/Striot/Orchestration.hs
@@ -85,7 +85,7 @@ chopAndChange opts sg = case viableRewrites opts sg of
 --   * return the 'Plan' paired with with the 'Cost' from applying the cost model.
 viableRewrites :: GenerateOpts -> StreamGraph -> [(Plan, Cost)]
 viableRewrites opts = deriveRewritesAndPartitionings (rules opts)
-                  >>> map (toSnd (uncurry (planCost opts)))
+                  >>> map (toSnd (planCost opts))
                   >>> filter (isJust . snd)
 
 test_viableRewrites_graph = assertNotEmpty $ viableRewrites defaultOpts graph
@@ -111,8 +111,8 @@ allPartitionsPaired sg = map (\pm -> (sg,pm)) (allPartitions sg)
 -- 'Nothing' if the 'Plan' is not viable,
 -- either due to an over-utilised operator or an over-utilised 'Partition'.
 --
-planCost :: GenerateOpts -> StreamGraph -> PartitionMap -> Cost
-planCost opts sg pm = let
+planCost :: GenerateOpts -> Plan -> Cost
+planCost opts (sg,pm) = let
     oi = calcAllSg sg
     in if   isOverUtilised oi || any (> maxNodeUtil opts) (totalNodeUtilisations oi pm)
        then Nothing
@@ -186,7 +186,7 @@ test_overUtilisedPartition_minThreePartitions = assertBool $
     (not . any (<3) . map (length.snd.fst) . viableRewrites defaultOpts) partUtilGraph
 
 test_overUtilisedPartition_rejected = -- example of an over-utilised partition
-    assertNothing (planCost defaultOpts partUtilGraph [[1,2],[3,4,5,6,7,8,9]])
+    assertNothing (planCost defaultOpts (partUtilGraph, [[1,2],[3,4,5,6,7,8,9]]))
 
 -- example of an acceptable PartitionMap
 test_overUtilisedPartition_acceptable = assertElem [[1,2,3],[4,5,6],[7,8,9]]


### PR DESCRIPTION
stop summing utility across the whole program; simplify the types;
rename to reflect that it is the cost function.