### PR TITLE
Update Haskell version, Stack LTS version, etc.

### DIFF
--- a/.github/workflows/build.workflow.yml
+++ b/.github/workflows/build.workflow.yml
@@ -3,6 +3,36 @@ name: Build and Test
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
+  cabal-build:
+    name: Cabal build
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ghc: ['8.6', '8.8', '8.10', '9.0']
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: ${{ matrix.ghc }}
+
+      - name: Install librdkafka
+        run: |
+          sudo apt-get update && sudo apt-get install librdkafka-dev
+
+      - name: Install Haskell deps
+        run: |
+          cabal install happy alex HTF
+          cabal install c2hs
+          cabal install --lib --only-dependencies --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
+
+      - name: Build and test striot
+        run: |
+          cabal configure --enable-tests && cabal build && cabal test
+
   stack-build:
     name: Stack build (+ examples)
     runs-on: ubuntu-latest

--- a/.github/workflows/build.workflow.yml
+++ b/.github/workflows/build.workflow.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        ghc: ['8.6', '8.8', '8.10', '9.0']
+        ghc: ['9.0']
       fail-fast: false
 
     steps:

--- a/containers/striot-base/Dockerfile
+++ b/containers/striot-base/Dockerfile
@@ -1,5 +1,5 @@
 # Run from a pre-built Haskell container
-FROM haskell:8.6
+FROM haskell:9.0.2-slim
 
 RUN apt-get update && apt-get upgrade -y
 
@@ -7,23 +7,23 @@ ENV LD_LIBRARY_PATH="/usr/local/lib"
 ENV LANG="C.UTF-8"
 
 # Install the librdkafka library for Kafka
-RUN git clone https://github.com/edenhill/librdkafka && \
-    cd librdkafka && \
-    git checkout $( git describe --tags --abbrev=0) && \
-    ./configure --install-deps && \
-    make && make install
+RUN apt-get install -y librdkafka-dev
 
 # Copy cabal file and license
 COPY striot/striot.cabal striot/LICENSE /opt/striot/
 
 WORKDIR /opt/striot
 
-# Install all dependencies defined in cabal file - we must install happy
-# separately for HTF, as the image has a bootstrapping problem
-RUN cabal v1-update && \
-    cabal v1-install happy-1.19.12 alex && \
-    cabal v1-install c2hs && \
-    cabal v1-install --only-dependencies --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib
+# Install all dependencies defined in cabal file
+RUN cabal update
+
+# happy to resolve HTF bootstrapping
+# c2hs for hw-kafka-client
+# alex c2hs
+RUN cabal v1-install happy alex && \
+    cabal v1-install c2hs
+RUN cabal v1-install --only-dependencies --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib --minimize-conflict-set
+
 
 # Copy over source code in a separate layer, ensuring above is cached if
 # cabal file does not change

--- a/src/ParallelIoT.hs
+++ b/src/ParallelIoT.hs
@@ -7,7 +7,7 @@ import Data.List
 type Distributor alpha = Stream alpha -> [(Int,Event alpha)]
 
 aStream:: Stream Int -- example stream
-aStream = [E i (read "2013-01-01 00:00:00") i|i<-[0..]]
+aStream = [E i (read "2013-01-01 00:00:00 +0000") i|i<-[0..]]
 
 parallelise:: Distributor alpha -> (Stream alpha -> Stream beta) -> Stream alpha -> Stream beta
 parallelise df f s = f $ map snd $ df s

--- a/src/Striot/Bandwidth.hs
+++ b/src/Striot/Bandwidth.hs
@@ -51,7 +51,7 @@ howBig = B.length . SS.encodeMessage . SS.Message
 -- so assume they do. The following figures calculated using the above
 
 e :: Store a => a -> Int
-e = howBig . Event (Just (addUTCTime 0 (read "2013-01-01 00:00:00"))) . Just
+e = howBig . Event (Just (addUTCTime 0 (read "2013-01-01 00:00:00 +0000"))) . Just
 
 -- these are types copied from examples/wearable. Longer term we should
 -- accept user-provided event sizes

--- a/src/Striot/FunctionalProcessing.hs
+++ b/src/Striot/FunctionalProcessing.hs
@@ -228,10 +228,10 @@ filterAcc accfn pred acc = let
 --t1 tLen sLen s = splitAtValuedEvents tLen (take sLen s)
 
 s1 :: Stream Int
-s1 = [(Event (Just (addUTCTime i (read "2013-01-01 00:00:00"))) (Just 999))|i<-[0..]]
+s1 = [(Event (Just (addUTCTime i (read "2013-01-01 00:00:00 +0000"))) (Just 999))|i<-[0..]]
 
 s2 :: Stream Int
-s2 = [Event (Just (addUTCTime i (read "2013-01-01 00:00:00"))) Nothing |i<-[0..]]
+s2 = [Event (Just (addUTCTime i (read "2013-01-01 00:00:00 +0000"))) Nothing |i<-[0..]]
 
 s3 :: Stream Int
 s3 = streamMerge [s1,s2]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,9 @@
-resolver: lts-13.25
+resolver: lts-19.0 # ghc-9.0.2
 packages:
 - .
 extra-deps:
-- network-3.1.0.0
-- prometheus-2.2.2
-- store-streaming-0.1.0.0
-- unagi-chan-0.4.1.0
-- net-mqtt-0.6.2.1
-- websockets-0.12.6.1
-- connection-0.3.1
-- socks-0.6.1
-- hw-kafka-client-3.0.0
-- envy-2.0.0.0
+- net-mqtt-0.8.2.0
+- aeson-2.0.2.0
+- attoparsec-0.13.2.5@sha256:1b64fc08464d9dc73d80e13aea362410f3c8bca5abfa6831df8821281c3cdfeb,6199
 - git: https://github.com/snowleopard/alga.git
   commit: 1623fae605503595ee331929157c61b5e5e0c1c7

--- a/striot.cabal
+++ b/striot.cabal
@@ -34,36 +34,38 @@ library
                       Striot.Orchestration
   -- other-modules:
   -- other-extensions:
-  build-depends:      base              >= 4.9
-                    , network           >= 3.1.0.0
-                    , containers        >= 0.5
-                    , split             >= 0.2
-                    , time              >= 1.6
-                    , HTF               >= 0.15
-                    , bytestring        >= 0.9.2
-                    , unagi-chan        >= 0.4.1.0
-                    , algebraic-graphs  >= 0.3
-                    , filepath          >= 1.4
-                    , directory         >= 1.3
-                    , store
-                    , store-streaming   >= 0.1.0
-                    , async
-                    , prometheus        >= 2.2.2
-                    , net-mqtt          >= 0.6.2.1 && <= 0.8.2.0
-                    , text
-                    , process
-                    , deepseq
-                    , network-uri       >= 2.6.1.0
-                    , hw-kafka-client   >= 3.0.0  && < 4.0.4
-                    , mtl               >= 2.2.2
-                    , lens              >= 4.17.1
-                    , envy              >= 2.0.0.0
-                    , utility-ht        >= 0.0.14
-                    , template-haskell  >= 2.14.0
-                    , syb
-                    , dsp               >= 0.2
-                    , array             >= 0.5
-                    , base-unicode-symbols >= 0.2
+  build-tool-depends: HTF:htfpp >= 0.15
+  build-depends:
+      algebraic-graphs     >= 0.6
+    , array                >= 0.5.4.0
+    , async                >= 2.2.4
+    , base                 >= 4.15.1
+    , base-unicode-symbols >= 0.2
+    , bytestring           >= 0.10.12.1
+    , containers           >= 0.6.4.1
+    , deepseq              >= 1.4.5.0
+    , directory            >= 1.3.6.2
+    , dsp                  >= 0.2.5.1
+    , envy                 >= 2.1.0.0
+    , filepath             >= 1.4.2.1
+    , HTF                  >= 0.15.0
+    , hw-kafka-client      >= 4.0.3 && < 4.0.4
+    , lens                 >= 5.0.1
+    , mtl                  >= 2.2.2
+    , net-mqtt             >= 0.8.2.0
+    , network              >= 3.1.2.7
+    , network-uri          >= 2.6.4.1
+    , process              >= 1.6.13.2
+    , prometheus           >= 2.2.3
+    , split                >= 0.2.3.4
+    , store                >= 0.7.14
+    , store-streaming      >= 0.2.0.3
+    , syb                  >= 0.7.2.1
+    , template-haskell     >= 2.17.0
+    , text                 >= 1.2.5.0
+    , time                 >= 1.9.3
+    , unagi-chan           >= 0.4.1.4
+    , utility-ht           >= 0.0.16
   hs-source-dirs:     src
   default-language:   Haskell2010
 
@@ -71,36 +73,38 @@ test-suite test-striot
   hs-source-dirs:     src
   type:               exitcode-stdio-1.0
   main-is:            TestMain.hs
-  build-depends:      base              >= 4.9
-                    , network           >= 3.1.0.0
-                    , containers        >= 0.5
-                    , split             >= 0.2
-                    , time              >= 1.6
-                    , HTF               >= 0.15
-                    , bytestring        >= 0.9.2
-                    , unagi-chan        >= 0.4.1.0
-                    , algebraic-graphs  >= 0.3
-                    , filepath          >= 1.4
-                    , directory         >= 1.3
-                    , store
-                    , store-streaming   >= 0.1.0
-                    , async
-                    , prometheus        >= 2.2.2
-                    , net-mqtt          >= 0.6.2.1 && <= 0.8.2.0
-                    , text
-                    , process
-                    , deepseq
-                    , network-uri       >= 2.6.1.0
-                    , hw-kafka-client   >= 3.0.0  && < 4.0.4
-                    , mtl               >= 2.2.2
-                    , lens              >= 4.17.1
-                    , envy              >= 2.0.0.0
-                    , utility-ht        >= 0.0.14
-                    , template-haskell  >= 2.14.0
-                    , syb
-                    , dsp               >= 0.2
-                    , array             >= 0.5
-                    , base-unicode-symbols >= 0.2
+  build-tool-depends: HTF:htfpp >= 0.15
+  build-depends:
+      algebraic-graphs     >= 0.6
+    , array                >= 0.5.4.0
+    , async                >= 2.2.4
+    , base                 >= 4.15.1
+    , base-unicode-symbols >= 0.2
+    , bytestring           >= 0.10.12.1
+    , containers           >= 0.6.4.1
+    , deepseq              >= 1.4.5.0
+    , directory            >= 1.3.6.2
+    , dsp                  >= 0.2.5.1
+    , envy                 >= 2.1.0.0
+    , filepath             >= 1.4.2.1
+    , HTF                  >= 0.15.0
+    , hw-kafka-client      >= 4.0.3 && < 4.0.4
+    , lens                 >= 5.0.1
+    , mtl                  >= 2.2.2
+    , net-mqtt             >= 0.8.2.0
+    , network              >= 3.1.2.7
+    , network-uri          >= 2.6.4.1
+    , process              >= 1.6.13.2
+    , prometheus           >= 2.2.3
+    , split                >= 0.2.3.4
+    , store                >= 0.7.14
+    , store-streaming      >= 0.2.0.3
+    , syb                  >= 0.7.2.1
+    , template-haskell     >= 2.17.0
+    , text                 >= 1.2.5.0
+    , time                 >= 1.9.3
+    , unagi-chan           >= 0.4.1.4
+    , utility-ht           >= 0.0.16
   other-modules:      Striot.CompileIoT
                       Striot.FunctionalIoTtypes
                       Striot.FunctionalProcessing

--- a/striot.cabal
+++ b/striot.cabal
@@ -39,7 +39,7 @@ library
                     , containers        >= 0.5
                     , split             >= 0.2
                     , time              >= 1.6
-                    , HTF
+                    , HTF               >= 0.15
                     , bytestring        >= 0.9.2
                     , unagi-chan        >= 0.4.1.0
                     , algebraic-graphs  >= 0.3
@@ -49,7 +49,7 @@ library
                     , store-streaming   >= 0.1.0
                     , async
                     , prometheus        >= 2.2.2
-                    , net-mqtt          >= 0.6.2.1 && <= 0.7.1.0
+                    , net-mqtt          >= 0.6.2.1 && <= 0.8.2.0
                     , text
                     , process
                     , deepseq
@@ -76,7 +76,7 @@ test-suite test-striot
                     , containers        >= 0.5
                     , split             >= 0.2
                     , time              >= 1.6
-                    , HTF
+                    , HTF               >= 0.15
                     , bytestring        >= 0.9.2
                     , unagi-chan        >= 0.4.1.0
                     , algebraic-graphs  >= 0.3
@@ -86,7 +86,7 @@ test-suite test-striot
                     , store-streaming   >= 0.1.0
                     , async
                     , prometheus        >= 2.2.2
-                    , net-mqtt          >= 0.6.2.1 && <= 0.7.1.0
+                    , net-mqtt          >= 0.6.2.1 && <= 0.8.2.0
                     , text
                     , process
                     , deepseq

--- a/striot.cabal
+++ b/striot.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                 striot
-version:              0.1.0.5
+version:              0.1.1.0
 -- synopsis:
 -- description:
 license:              Apache


### PR DESCRIPTION
 attempt to upgrade the versions of Haskell, Stack, Docker images, etc. that we use to the current stable versions where possible.

The current lates stable GHC version is Version 9.2.2 (released 5th March 2022) but the latest Stack LTS release is LTS Haskell 19.0 (ghc-9.0.2).

I started by specifying that and then removing as many of the exceptions/bounds in stack.yaml as possible.

The first conflict to resolve was: HTF depends on aeson (unbounded); aeson depends on attoparsec (>=0.14.2 && <0.15),  net-mqtt-0.8.2.0 depends on attoparsec (>=0.13.2 && <0.14), incompatible bounds. One solution was to pin an earlier aeson version, with a bounds that fits net-mqtt.

The next issue was a breaking change in net-mqtt from 0.8 onwards. I've addressed that in the two places it mattered for us, but this isn't my code and I'm not too familiar with it -- in particular if the Text fails validation as a topic or filter, then using `fromJust` will cause a run time fatal error. Is that a possible outcome?
