### PR TITLE
Add upper bound on kafka dependency to fix CI

### DIFF
--- a/striot.cabal
+++ b/striot.cabal
@@ -53,7 +53,7 @@ library
                     , process
                     , deepseq
                     , network-uri       >= 2.6.1.0
-                    , hw-kafka-client   >= 3.0.0 
+                    , hw-kafka-client   >= 3.0.0  && < 4.0.4
                     , mtl               >= 2.2.2
                     , lens              >= 4.17.1
                     , envy              >= 2.0.0.0
@@ -89,7 +89,7 @@ test-suite test-striot
                     , process
                     , deepseq
                     , network-uri       >= 2.6.1.0
-                    , hw-kafka-client   >= 3.0.0
+                    , hw-kafka-client   >= 3.0.0  && < 4.0.4
                     , mtl               >= 2.2.2
                     , lens              >= 4.17.1
                     , envy              >= 2.0.0.0


### PR DESCRIPTION
hw-kafka-client version 4.0.4 introduced headers for consumed/produced
records, which is a breaking change and requires code updates.

Signed-off-by: Jonathan Dowland <jon@dow.land>