### PR TITLE
Update version of github actions/checkout

### DIFF
--- a/.github/workflows/build.workflow.yml
+++ b/.github/workflows/build.workflow.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: haskell/actions/setup@v1
         with:
@@ -37,7 +37,7 @@ jobs:
     name: Stack build (+ examples)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: haskell/actions/setup@v1
         with:

--- a/.github/workflows/deploy.workflow.yml
+++ b/.github/workflows/deploy.workflow.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin


### PR DESCRIPTION
v2 has been deprecated and the CI started failing. Current version is v3.3.0. Use 'v3' so we track updates until the next major version bump.