### PR TITLE
cabal: bracket algebraic-graphs to < 0.7

### DIFF
--- a/striot.cabal
+++ b/striot.cabal
@@ -36,7 +36,7 @@ library
   -- other-extensions:
   build-tool-depends: HTF:htfpp >= 0.15
   build-depends:
-      algebraic-graphs     >= 0.6
+      algebraic-graphs     >= 0.6 && < 0.7
     , array                >= 0.5.4.0
     , async                >= 2.2.4
     , base                 >= 4.15.1
@@ -75,7 +75,7 @@ test-suite test-striot
   main-is:            TestMain.hs
   build-tool-depends: HTF:htfpp >= 0.15
   build-depends:
-      algebraic-graphs     >= 0.6
+      algebraic-graphs     >= 0.6 && < 0.7
     , array                >= 0.5.4.0
     , async                >= 2.2.4
     , base                 >= 4.15.1


### PR DESCRIPTION
0.7 swaps the order of arguments for some functions including `reachable`.

Since the stack builds use 0.6(.*), pin the cabal version to match, rather than fix the argument order (breaking stack)