### PR TITLE
Image is tagged by branch not latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_TOOL ?= docker
 REGISTRY ?= ghcr.io
 ORG ?= striot
 IMAGE ?= striot
-VERSION ?= latest
+VERSION ?= main
 
 GHC := stack ghc -- -XTemplateHaskell
 default: default2

--- a/examples/container-pipeline/link/Dockerfile
+++ b/examples/container-pipeline/link/Dockerfile
@@ -1,5 +1,5 @@
 # Run from a pre-built Haskell container
-FROM ghcr.io/striot/striot:latest
+FROM ghcr.io/striot/striot:main
 
 # Add and Install Application Code
 COPY . /opt/haskell

--- a/examples/container-pipeline/sink/Dockerfile
+++ b/examples/container-pipeline/sink/Dockerfile
@@ -1,5 +1,5 @@
 # Run from a pre-built Haskell container
-FROM ghcr.io/striot/striot:latest
+FROM ghcr.io/striot/striot:main
 
 # Add and Install Application Code
 COPY . /opt/haskell

--- a/examples/container-pipeline/source/Dockerfile
+++ b/examples/container-pipeline/source/Dockerfile
@@ -1,5 +1,5 @@
 # Run from a pre-built Haskell container
-FROM ghcr.io/striot/striot:latest
+FROM ghcr.io/striot/striot:main
 
 # Add and Install Application Code
 COPY . /opt/haskell

--- a/examples/pipeline-kafka/node1/Dockerfile
+++ b/examples/pipeline-kafka/node1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/striot/striot:latest
+FROM ghcr.io/striot/striot:main
 WORKDIR /opt/node
 COPY . /opt/node
 

--- a/examples/pipeline-kafka/node2/Dockerfile
+++ b/examples/pipeline-kafka/node2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/striot/striot:latest
+FROM ghcr.io/striot/striot:main
 WORKDIR /opt/node
 COPY . /opt/node
 

--- a/examples/pipeline-kafka/node3/Dockerfile
+++ b/examples/pipeline-kafka/node3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/striot/striot:latest
+FROM ghcr.io/striot/striot:main
 WORKDIR /opt/node
 COPY . /opt/node
 

--- a/examples/pipeline-mqtt/node1/Dockerfile
+++ b/examples/pipeline-mqtt/node1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/striot/striot:latest
+FROM ghcr.io/striot/striot:main
 WORKDIR /opt/node
 COPY . /opt/node
 

--- a/examples/pipeline-mqtt/node2/Dockerfile
+++ b/examples/pipeline-mqtt/node2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/striot/striot:latest
+FROM ghcr.io/striot/striot:main
 WORKDIR /opt/node
 COPY . /opt/node
 

--- a/examples/pipeline-mqtt/node3/Dockerfile
+++ b/examples/pipeline-mqtt/node3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/striot/striot:latest
+FROM ghcr.io/striot/striot:main
 WORKDIR /opt/node
 COPY . /opt/node
 

--- a/gen_test_makefile.sh
+++ b/gen_test_makefile.sh
@@ -26,7 +26,7 @@ gen()
     echo REGISTRY \?= ghcr.io
     echo ORG \?= striot
     echo IMAGE \?= striot
-    echo VERSION \?= latest
+    echo VERSION \?= main
     echo
     echo GHC := stack ghc -- -XTemplateHaskell
     echo default: default2

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -362,7 +362,7 @@ test_reform_s1_2 = assertEqual s1 (unPartition $ createPartitions s1 [[0],[1,2]]
 
 genDockerfile listen opts = 
     let pkgs = packages opts in concat
-    [ "FROM ghcr.io/striot/striot:latest\n"
+    [ "FROM ghcr.io/striot/striot:main\n"
     , "WORKDIR /opt/node\n"
     , "COPY . /opt/node\n"
     , if pkgs /= [] then "RUN cabal install " ++ (intercalate " " pkgs) else ""


### PR DESCRIPTION
Follow up to #169, looks like the package was published at `ghcr.io/striot/striot:main`, not `ghcr.io/striot/striot:latest`.

The package was by default private so I've also made it public so it can be pulled now.