### PR TITLE
taxi: fix parsing dates from CSV

### DIFF
--- a/examples/taxi/Taxi.hs
+++ b/examples/taxi/Taxi.hs
@@ -9,6 +9,7 @@ import           Data.Maybe                  (fromJust)
 import           Data.Store
 import           Data.Time                   (NominalDiffTime, UTCTime (..),
                                               addUTCTime, fromGregorianValid)
+import           Data.Time.Format            (parseTimeOrError, defaultTimeLocale)
 import           GHC.Generics                (Generic)
 import           Striot.FunctionalIoTtypes
 import           Striot.FunctionalProcessing
@@ -127,12 +128,16 @@ tripSource s = map ((\t -> Event (Just (dropoffDatetime t)) (Just t))
 stringsToTrip :: [String] -> Trip
 stringsToTrip [med, hack, pickupDateTime, dropoffDateTime, trip_time, trip_dist, pickup_long, pickup_lat,
                dropoff_long, dropoff_lat, pay_type, fare, sur, mta, tip, tolls, total] =
-   Trip med hack (read pickupDateTime) (read dropoffDateTime) (read trip_time) (read trip_dist)
+   Trip med hack (parseTimeField pickupDateTime) (parseTimeField dropoffDateTime) (read trip_time) (read trip_dist)
                  (Location (read pickup_lat)  (read pickup_long))
                  (Location (read dropoff_lat) (read dropoff_long))
                  (if pay_type == "CRD" then Card else Cash)
                  (read fare) (read sur) (read mta) (read tip) (read tolls) (read total)
 stringsToTrip s = error ("error in input: " ++ intercalate "," s)
+
+-- time field parser
+parseTimeField :: String -> UTCTime
+parseTimeField = parseTimeOrError True defaultTimeLocale "%Y-%-m-%-d %H:%M:%S"
 
 ----------------------------------------------------------------------------------------------------------------
 

--- a/examples/taxi/generate.hs
+++ b/examples/taxi/generate.hs
@@ -10,7 +10,7 @@ import Data.Time -- UTCTime(..)
 import Data.Maybe (fromJust)
 import Data.List.Split (splitOn)
 
-opts = GenerateOpts { imports = imports defaultOpts ++
+opts = defaultOpts { imports = imports defaultOpts ++
                         [ "Taxi"
                         , "Data.Maybe"
                         , "Data.List.Split"


### PR DESCRIPTION
More recent versions of the time library changed the 'read' implementation
to fail unless the string included the UTC offset suffix (e.g. +0000). The
Taxi data does not include that.

Switch to calling `parseTimeOrError` with a format specification.