### PR TITLE
Split build workflow up, replace Stack actions with freckle/stack-action, publish Haddock to GH Pages

### DIFF
--- a/.github/workflows/cabal.build.workflow.yml
+++ b/.github/workflows/cabal.build.workflow.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Cabal Build and Test
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -32,31 +32,3 @@ jobs:
       - name: Build and test striot
         run: |
           cabal configure --enable-tests && cabal build && cabal test
-
-  stack-build:
-    name: Stack build (+ examples)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: haskell/actions/setup@v1
-        with:
-          ghc-version: '8.6'
-          enable-stack: true
-
-      - name: Install librdkafka and graphviz (for dot)
-        run: |
-          sudo apt-get update && sudo apt-get install librdkafka-dev graphviz
-
-      - name: Install Haskell deps
-        run: |
-          stack install happy alex HTF
-          stack install c2hs
-          stack install --only-dependencies
-
-      - name: Build and test striot
-        run: |
-          stack build && stack install && stack test
-      - name: Build examples
-        run: |
-          ./gen_test_makefile.sh > Makefile; make

--- a/.github/workflows/stack.build.workflow.yml
+++ b/.github/workflows/stack.build.workflow.yml
@@ -8,25 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: haskell/actions/setup@v1
-        with:
-          ghc-version: '8.6'
-          enable-stack: true
-
       - name: Install librdkafka and graphviz (for dot)
         run: |
           sudo apt-get update && sudo apt-get install librdkafka-dev graphviz
-
-      - name: Install Haskell deps
-        run: |
-          stack install happy alex HTF
-          stack install c2hs
-          stack install --only-dependencies
-
-      - name: Build and test striot
-        run: |
-          stack build && stack install && stack test
+      - uses: freckle/stack-action@v4
+        with:
+          pedantic: false
       - name: Build examples
         run: |
-          ./gen_test_makefile.sh > Makefile; make
+          ./gen_test_makefile.sh > Makefile
+          make

--- a/.github/workflows/stack.build.workflow.yml
+++ b/.github/workflows/stack.build.workflow.yml
@@ -1,0 +1,32 @@
+name: Stack Build and Test
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  stack-build:
+    name: Stack build (+ examples)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: '8.6'
+          enable-stack: true
+
+      - name: Install librdkafka and graphviz (for dot)
+        run: |
+          sudo apt-get update && sudo apt-get install librdkafka-dev graphviz
+
+      - name: Install Haskell deps
+        run: |
+          stack install happy alex HTF
+          stack install c2hs
+          stack install --only-dependencies
+
+      - name: Build and test striot
+        run: |
+          stack build && stack install && stack test
+      - name: Build examples
+        run: |
+          ./gen_test_makefile.sh > Makefile; make

--- a/.github/workflows/stack.build.workflow.yml
+++ b/.github/workflows/stack.build.workflow.yml
@@ -2,10 +2,23 @@ name: Stack Build and Test
 
 on: [push, pull_request, workflow_dispatch]
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   stack-build:
     name: Stack build (+ examples)
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v3
       - name: Install librdkafka and graphviz (for dot)
@@ -14,7 +27,23 @@ jobs:
       - uses: freckle/stack-action@v4
         with:
           pedantic: false
+          stack-arguments: --no-haddock-deps --haddock --haddock-arguments "-o haddock"
       - name: Build examples
         run: |
           ./gen_test_makefile.sh > Makefile
           make
+
+      - if: github.event_name != 'pull_request'
+        name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - if: github.event_name != 'pull_request'
+        name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: haddock/
+
+      - if: github.event_name != 'pull_request'
+        name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
The "publish to GH pages" bit won't trigger until after the PR is merged. Preview here: https://github.com/jmtd/striot/tree/freckle-stack-action , https://jmtd.github.io/striot/

The freckle action caching is a huge time saver. The first run on my branch took 20m, and the next run took 3m.