### PR TITLE
Adjust GHA github-pages actions

### DIFF
--- a/.github/workflows/stack.build.workflow.yml
+++ b/.github/workflows/stack.build.workflow.yml
@@ -1,24 +1,10 @@
 name: Stack Build and Test
-
 on: [push, pull_request, workflow_dispatch]
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
 
 jobs:
   stack-build:
     name: Stack build (+ examples)
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v3
       - name: Install librdkafka and graphviz (for dot)
@@ -33,17 +19,32 @@ jobs:
           ./gen_test_makefile.sh > Makefile
           make
 
-      - if: github.event_name != 'pull_request'
+      - if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         name: Setup Pages
         uses: actions/configure-pages@v3
 
-      - if: github.event_name != 'pull_request'
+      - if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
           path: haddock/
 
-      - if: github.event_name != 'pull_request'
-        name: Deploy to GitHub Pages
-        id: deployment
+  deploy-pages:
+    name: Deploy Haddock docs to GitHub Pages
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: stack-build
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v2


### PR DESCRIPTION
Tweak the github-pages stuff so it is properly gated behind GitHub action type, to try and stop a situation whereby Deployments are failing for every PR.