### PR TITLE
small code improvements (CostedPlan, getConsumer)

### DIFF
--- a/src/Striot/Bandwidth.hs
+++ b/src/Striot/Bandwidth.hs
@@ -152,9 +152,9 @@ whatBandwidthWeighted g i = fmap (+ (departRate g i * weighting)) (whatBandwidth
 -- XXX: write an "departSize"? we could estimate window sizes for fixed-length
 -- or time-bound windows for example. Joins approx double, etc
 
--- | Does this StreamGraph breach a bandwidth limit?
-overBandwidthLimit :: StreamGraph -> PartitionMap -> Double -> Bool
-overBandwidthLimit sg pm bandwidthLimit = let
+-- | Does this 'Plan' breach a bandwidth limit?
+overBandwidthLimit :: Plan -> Double -> Bool
+overBandwidthLimit (Plan sg pm) bandwidthLimit = let
   sourceIds = (map vertexId . filter (isSource . operator) . vertexList) sg
   connected = connectedToSources sourceIds pm
 
@@ -167,7 +167,7 @@ overBandwidthLimit sg pm bandwidthLimit = let
 
 -- XXX: tests or overBandwidthLimit
 
-test_overBandwidthLimit = assertBool $ overBandwidthLimit graph [[1,2],[3,4],[5,6]] 29
+test_overBandwidthLimit = assertBool $ overBandwidthLimit (Plan graph [[1,2],[3,4],[5,6]]) 29
 
 -- | Provide a flattened list of node IDs from a PartitionMap which are
 -- connected to a source node within a partition.

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -8,6 +8,7 @@ module Striot.CompileIoT ( createPartitions
                          , defaultOpts
                          , Partition
                          , PartitionMap
+                         , Plan(..)
                          , writePart
                          , genDockerfile
                          , partitionGraph
@@ -50,6 +51,11 @@ type Partition = Int
 -- Each element in the outer-most list corresponds to a distinct partition.
 -- The inner-lists are the IDs of Operators to include in that partition.
 type PartitionMap = [[Int]]
+
+-- | A Plan is a pairing of a 'StreamGraph' with a 'PartitionMap' that could
+-- be used for its partitioning and deployment.
+data Plan = Plan { planStreamGraph  :: StreamGraph
+                 , planPartitionMap :: PartitionMap }
 
 -- |`createPartitions` returns ([partitions], [inter-graph links])
 -- where inter-graph links are the cut edges due to partitioning


### PR DESCRIPTION
Introduce two new ADTs in place of where I was using tuples previously:

 * Plan
 * CostedPlan

The key point is captured in this change

```diff
-    rs -> rs & sortOn snd & head & fst
+    rs -> rs & sortOn costedPlanCost & head & costedPlanPlan
```

or

```diff
-    $ (map (snd.fst) . viableRewrites opts) partUtilGraph -- :: [PartitionMap]
+    $ (map (planPartitionMap.costedPlanPlan) . viableRewrites opts) partUtilGraph -- :: [PartitionMap]
```

I.e. chains of composed `fst`,`snd`,`head` and so on that obscure what the intermediate types are.

Also a smaller, self contained change to `Striot.CompileIoT.Compose.getConsumer` to move an implicit requirement that a list had arity 0 or 1 to the type system (using `Maybe`).