### PR TITLE
Logical Optimiser: Tree of rewrites

### DIFF
--- a/examples/wearable/WearableStats.hs
+++ b/examples/wearable/WearableStats.hs
@@ -51,7 +51,7 @@ test_defaultgraph_bwlimit = assertEmpty $ norewritePlans
 ---- Evaluation Stage 2: logical optimiser/rewrites
 
 -- how many program variants are derived?
-rewrites            = (nub . applyRules (rules opts) 5) graph
+rewrites            = (nub . map variantGraph . rewriteGraph (rules opts)) graph
 rewriteVariantCount = length rewrites - 1 -- 57
 plans               = concatMap makePlans rewrites
 rewritePlanCount    = length plans -- 5718

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -95,7 +95,7 @@ data GenerateOpts = GenerateOpts
   { imports           :: [String]      -- ^ list of import statements to add to generated files
   , packages          :: [String]      -- ^ list of Cabal packages to install within containers
   , preSource         :: Maybe String  -- ^ code to run prior to starting 'nodeSource'
-  , rules             :: [RewriteRule] -- ^ A list of rewrite rules for the logical optimiser
+  , rules             :: [LabelledRewriteRule] -- ^ A list of rewrite rules for the logical optimiser
   , maxNodeUtil       :: Double        -- ^ The per-Partition utilisation limit
   , bandwidthLimit    :: Double        -- ^ A program-global maximum bandwidth limit
   }

--- a/src/Striot/LogicalOptimiser.hs
+++ b/src/Striot/LogicalOptimiser.hs
@@ -62,17 +62,17 @@ applyRule f g = g & fromMaybe id (firstMatch g f)
 -- recursively attempt to apply the rule to the graph, but stop
 -- as soon as we get a match
 firstMatch :: StreamGraph -> RewriteRule -> Maybe (StreamGraph -> StreamGraph)
-firstMatch g f = case f g of
+firstMatch g r = case r g of
         Just f -> Just f
         _      -> case g of
             Empty       -> Nothing
-            Vertex v    -> Nothing
-            Overlay a b -> case firstMatch a f of
+            Vertex _    -> Nothing
+            Overlay a b -> tryLeftThenRight a b r
+            Connect a b -> tryLeftThenRight a b r
+        where
+            tryLeftThenRight a b r = case firstMatch a r of
                                 Just f  -> Just f
-                                Nothing -> firstMatch b f
-            Connect a b -> case firstMatch a f of
-                                Just f  -> Just f
-                                Nothing -> firstMatch b f
+                                Nothing -> firstMatch b r
 
 -- N-bounded recursive rule traversal
 -- (caller may wish to apply 'nub')

--- a/src/Striot/LogicalOptimiser/RewriteRule.hs
+++ b/src/Striot/LogicalOptimiser/RewriteRule.hs
@@ -1,0 +1,29 @@
+{-# OPTIONS_GHC -F -pgmF htfpp #-}
+{-# OPTIONS_HADDOCK prune #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Striot.LogicalOptimiser.RewriteRule ( LabelledRewriteRule(..)
+                                           , RewriteRule(..)
+                                           , lrule
+                                           ) where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Syntax
+import Test.Framework
+
+import Striot.StreamGraph
+
+type RewriteRule = StreamGraph -> Maybe (StreamGraph -> StreamGraph)
+
+-- | A pairing of a `RewriteRule` with its name, encoded in a `String`.
+data LabelledRewriteRule = LabelledRewriteRule
+    { ruleLabel :: String
+    , rule :: RewriteRule }
+
+-- | convenience function so one can write `$(lrule 'someRule)` rather than
+-- `LabelledRewriteRule "someRule" someRule`.
+-- This function needs to live in a separate module from LogicalOptimiser due
+-- to technical limitations with Template Haskell.
+lrule :: Quasi m => Name -> m Exp
+lrule name = return $
+    ConE 'LabelledRewriteRule `AppE` ((LitE . StringL . nameBase) name) `AppE` VarE name

--- a/src/Striot/Orchestration.hs
+++ b/src/Striot/Orchestration.hs
@@ -40,7 +40,7 @@ import Control.Arrow ((>>>))
 import Striot.CompileIoT
 import Striot.CompileIoT.Compose (generateDockerCompose)
 import Striot.Jackson
-import Striot.LogicalOptimiser (applyRules, RewriteRule)
+import Striot.LogicalOptimiser
 import Striot.Partition
 import Striot.StreamGraph
 import Striot.VizGraph
@@ -100,8 +100,11 @@ test_viableRewrites_tooMuch = assertEmpty  $ viableRewrites defaultOpts tooMuch
 
 -- | given a 'StreamGraph', derives further graphs by applying rewrite
 -- rules and pairs them with all their potential partitionings
-deriveRewritesAndPartitionings :: [RewriteRule] -> StreamGraph -> [Plan]
-deriveRewritesAndPartitionings rs = concatMap makePlans . nub . applyRules rs 5
+deriveRewritesAndPartitionings :: [LabelledRewriteRule] -> StreamGraph -> [Plan]
+deriveRewritesAndPartitionings rs = concatMap makePlans
+                                  . nub
+                                  . map variantGraph
+                                  . rewriteGraph rs
 
 -- | given a 'StreamGraph', generate all partitionings of it and pair
 -- | Generate all partitionings for the supplied 'StreamGraph' and pair


### PR DESCRIPTION
Adjust the logical optimiser so that it produces a "tree of rewrites": each variant rewrite is a data-type which references the streamgraph from which it was derived as well as the rule that was applied to derive it.

This is to greatly improve the ability to explore what the Logical Optimiser has done, how a given variant stream program was arrived at, and to aid in debugging things such as why two seemingly-equivalent streamgraphs are not considered equivalent, etc.