### PR TITLE
chopTime: exhaustive patterns

### DIFF
--- a/src/Striot/FunctionalProcessing.hs
+++ b/src/Striot/FunctionalProcessing.hs
@@ -117,6 +117,7 @@ chop wLength s = chop' wLength $ filter dataEvent s
 
 chopTime :: Int -> WindowMaker alpha -- N.B. discards events without a timestamp
 chopTime _       []                         = []
+chopTime t ((Event Nothing _):s)            = chopTime t s
 chopTime tLength s@((Event (Just t) _):_) = chopTime' (milliToTimeDiff tLength) t $ filter timedEvent s
     where chopTime' :: NominalDiffTime -> UTCTime -> WindowMaker alpha -- the first argument is in milliseconds
           chopTime' _    _      []    = []


### PR DESCRIPTION
Before:
    λ> chopTime 5 $ mkStream [1,2,3,4,5]
    *** Exception: FunctionalProcessing.hs:(120,1)-(126,83): Non-exhaustive patterns in function chopTime

After:
    λ> chopTime 5 $ mkStream [1,2,3,4,5]
    []

(where mkStream generates Events without timestamps)