### PR TITLE
Bandwidth cleanup 2025

### DIFF
--- a/src/Striot/Bandwidth.hs
+++ b/src/Striot/Bandwidth.hs
@@ -163,7 +163,8 @@ whatBandwidth g i =
   in fmap ((*outrate)) outsize
 
 -- applies a rate-based overhead weighting
-weighting = 2.0
+-- TCP header size is 20-40 bytes; IP header size is 20-40 bytes
+weighting = 60.0
 whatBandwidthWeighted g i = fmap (+ (departRate g i * weighting)) (whatBandwidth g i)
 
 -- XXX: write an "departSize"? we could estimate window sizes for fixed-length

--- a/src/Striot/Bandwidth.hs
+++ b/src/Striot/Bandwidth.hs
@@ -113,7 +113,9 @@ departRate g i = let
 
     Window      -> let params = (words . showParam . head . parameters) v in
                    if   "chopTime" == head params
-                   then 1 / read (params !! 1)
+                   then let ms = read (params !! 1)
+                            s  = ms / 1000
+                        in  1 / s
                    else departRate g p
 
     _           -> departRate g p
@@ -130,7 +132,7 @@ v9 = StreamVertex 9 Window [[| chopTime 120 |]] "a" "[a]" 9
 
 graph3 = path [v1, v2, v9, v7, v6]
 
-test_departRate_window = assertEqual (1/120) $ departRate graph3 9
+test_departRate_window = assertEqual (1/0.12) $ departRate graph3 9
 
 ------------------------------------------------------------------------------
 

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -113,7 +113,7 @@ defaultOpts = GenerateOpts
   , preSource   = Nothing
   , rules       = defaultRewriteRules
   , maxNodeUtil = 3.0 -- finger in the air
-  , bandwidthLimit = 31 -- same
+  , bandwidthLimit = 200 -- same
   }
 
 -- |Partitions the supplied `StreamGraph` according to the supplied `PartitionMap`

--- a/src/Striot/Orchestration.hs
+++ b/src/Striot/Orchestration.hs
@@ -203,9 +203,7 @@ test_overUtilisedPartition_rejected = -- example of an over-utilised partition
 -- example of an acceptable PartitionMap
 test_overUtilisedPartition_acceptable = assertElem [[1,2,3],[4,5,6],[7,8,9]]
     $ map (sort . (map sort))
-    $ (map (planPartitionMap.costedPlanPlan) . viableRewrites opts) partUtilGraph -- :: [PartitionMap]
-    where
-        opts = defaultOpts { bandwidthLimit = 46 }
+    $ (map (planPartitionMap.costedPlanPlan) . viableRewrites defaultOpts) partUtilGraph -- :: [PartitionMap]
 
 {- $fromCompileIoT
 == CompileIoT functions


### PR DESCRIPTION
Fix handling of `streamWindow chopTime`, adjust bandwidth weighting to reflect TCP/IP packet overhead, fix departRate calculation for chopTime (miliseconds versus seconds)