### PR TITLE
GHA: Move freckle/stack-action to v5

### DIFF
--- a/.github/workflows/stack.build.workflow.yml
+++ b/.github/workflows/stack.build.workflow.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install librdkafka and graphviz (for dot)
         run: |
           sudo apt-get update && sudo apt-get install librdkafka-dev graphviz
-      - uses: freckle/stack-action@v4
+      - uses: freckle/stack-action@v5
         id: stack
         with:
           pedantic: false


### PR DESCRIPTION
This should fix the caching related aspect of Stack builds.