### PR TITLE
rename bandwidthLimit to maxBandwidth

### DIFF
--- a/examples/wearable/WearableStats.hs
+++ b/examples/wearable/WearableStats.hs
@@ -29,7 +29,7 @@ toSnd f a = (a, f a)
 lrules = defaultRewriteRules ++ reshapingRules
 
 opts = defaultOpts { maxNodeUtil    = 1.1102e-4
-                   , bandwidthLimit = 1760
+                   , maxBandwidth   = 1760
                    , rules          = lrules
                    }
 
@@ -69,7 +69,7 @@ norewritePlans = makePlans graph
 norewritePartitionCount = length $ norewritePlans
 
 -- how many of those are not eliminated by maxNodeUtil (112)
-relaxedOpts = opts { bandwidthLimit = 999999999 }
+relaxedOpts = opts { maxBandwidth = 999999999 }
 norewritePassMaxNodeUtil' o = norewritePlans
                             & map (toSnd (planCost o))
                             & filter (isJust . snd)
@@ -183,7 +183,7 @@ wearableParams = "  \\begin{tabular}{ll}\n"
  ++ "    Parameter      & Value         \\\\\n"
  ++ "    \\midrule\n"
  ++ "    maxNodeUtil    & "++(show (100*(maxNodeUtil opts)))++"\\%         \\\\\n"
- ++ "    bandwidthLimit & "++(show (bandwidthLimit opts))++"bytes/s \\\\\n"
+ ++ "    maxBandwidth   & "++(show (maxBBandwidth opts))++"bytes/s \\\\\n"
  ++ "    rules          & defaultRewriteRules ++ reshapingRules \\\\\n"
  ++ "  \\end{tabular}\n"
 

--- a/src/Striot/CompileIoT.hs
+++ b/src/Striot/CompileIoT.hs
@@ -100,7 +100,7 @@ data GenerateOpts = GenerateOpts
   , preSource         :: Maybe String  -- ^ code to run prior to starting 'nodeSource'
   , rules             :: [LabelledRewriteRule] -- ^ A list of rewrite rules for the logical optimiser
   , maxNodeUtil       :: Double        -- ^ The per-Partition utilisation limit
-  , bandwidthLimit    :: Double        -- ^ A program-global maximum bandwidth limit
+  , maxBandwidth      :: Double        -- ^ Bandwidth limit between the first two deployment Nodes
   }
 
 -- | Sensible default values for 'GenerateOpts'. Users who wish to customise
@@ -115,8 +115,8 @@ defaultOpts = GenerateOpts
   , packages    = []
   , preSource   = Nothing
   , rules       = defaultRewriteRules
-  , maxNodeUtil = 3.0 -- finger in the air
-  , bandwidthLimit = 200 -- same
+  , maxNodeUtil = 3.0
+  , maxBandwidth= 200
   }
 
 -- |Partitions the supplied `StreamGraph` according to the supplied `PartitionMap`

--- a/src/Striot/Orchestration.hs
+++ b/src/Striot/Orchestration.hs
@@ -122,7 +122,7 @@ planCost opts plan@(Plan sg pm) = let
     oi = calcAllSg sg
     in if   isOverUtilised oi
          || any (> maxNodeUtil opts) (totalNodeUtilisations oi pm)
-         || overBandwidthLimit plan (bandwidthLimit opts)
+         || overBandwidthLimit plan (maxBandwidth opts)
        then Nothing
        else Just (length pm)
 


### PR DESCRIPTION
This is closer to the scheme used to encode maximum node utilisation (maxNodeUtil) and in particular makes the following in Orchestration clearer:

    overBandwidthLimit plan (maxBandwidth opts)